### PR TITLE
feat: Add extra-prompt flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ bun claude-code-cli.ts --eval 001-server-component --verbose
 
 # Debug mode - keep output folders
 bun claude-code-cli.ts --eval 001-server-component --debug
+
+# Add extra prompt instructions from a file
+bun claude-code-cli.ts --eval 001-server-component --extra-prompt extra-prompt.md
 ```
 
 #### Claude Code with Dev Server and Hooks

--- a/cli.ts
+++ b/cli.ts
@@ -298,6 +298,8 @@ function parseCliArgs(args: string[]) {
       values["with-hooks"] = args[++i];
     } else if (arg === "--with-visual-diff") {
       values["with-visual-diff"] = true;
+    } else if (arg === "--extra-prompt") {
+      values["extra-prompt"] = args[++i];
     } else if (!arg.startsWith("-")) {
       positionals.push(arg);
     }
@@ -336,6 +338,7 @@ Options:
       --dev-server-port   Port for dev server (default: 4000, auto-increments for concurrent evals)
       --with-hooks <name> Use eval hooks from scripts/eval-hooks/<name>-pre.sh and <name>-post.sh
       --with-visual-diff  Enable visual regression testing with screenshot comparison
+      --extra-prompt <path> Path to file with extra prompt content to append
 
 Examples:
   # Run all evals with LLMs
@@ -1506,6 +1509,7 @@ async function main() {
           : undefined,
         hooks,
         visualDiff: values["with-visual-diff"] || false,
+        extraPrompt: values["extra-prompt"],
       };
 
       if (values.all) {

--- a/extra-prompt.md
+++ b/extra-prompt.md
@@ -1,0 +1,3 @@
+You are a professional Next.js and TypeScript expert!
+- Be sure to check linting and fix any linter errors
+- Be sure to check the build and fix any build errors

--- a/lib/claude-code-runner.ts
+++ b/lib/claude-code-runner.ts
@@ -47,6 +47,7 @@ export interface ClaudeCodeEvalOptions {
   visualDiff?: boolean;
   outputFormat?: string;
   outputFile?: string;
+  extraPrompt?: string;
 }
 
 export class ClaudeCodeRunner {
@@ -727,7 +728,17 @@ export async function runClaudeCodeEval(
     throw new Error(`No prompt.md file found in ${evalPath}`);
   }
 
-  const prompt = await fs.readFile(promptFile, "utf8");
+  let prompt = await fs.readFile(promptFile, "utf8");
+
+  // Read extra prompt from file if specified (append to end)
+  if (options.extraPrompt) {
+    try {
+      const extraPrompt = await fs.readFile(options.extraPrompt, "utf8");
+      prompt = `${prompt}\n\n${extraPrompt}`;
+    } catch (error) {
+      throw new Error(`Failed to read extra prompt file: ${error}`);
+    }
+  }
 
   let outputDir: string;
   let worktreePath: string | undefined;


### PR DESCRIPTION
This allows `--extra-prompt <PATH>` to be passed, which simply appends the prompt to the contents of `prompt.md`.

I've also included `extra-prompt.md`. We found this massively improved results across almost every task when appended - but it also serves as a placeholder :)