### PR TITLE
feat: Add --capture-conversation (Claude Code only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,19 @@ bun claude-code-cli.ts --eval 001-server-component --verbose
 
 # Debug mode - keep output folders
 bun claude-code-cli.ts --eval 001-server-component --debug
+
+# Capture full conversation with tool calls (Claude Code only)
+bun claude-code-cli.ts --eval 001-server-component --capture-conversation
 ```
+
+**Conversation Capture (Claude Code only):**
+
+Use the `--capture-conversation` flag to save the full conversation including all tool calls in JSONL format:
+
+- `claude-conversation.jsonl` - Complete conversation with all tool calls and responses in JSONL format
+- `claude-output.txt` - Human-readable summary of the evaluation
+
+These files are saved in the output directory (`output-claude-code/`).
 
 #### Claude Code with Dev Server and Hooks
 

--- a/cli.ts
+++ b/cli.ts
@@ -298,6 +298,8 @@ function parseCliArgs(args: string[]) {
       values["with-hooks"] = args[++i];
     } else if (arg === "--with-visual-diff") {
       values["with-visual-diff"] = true;
+    } else if (arg === "--capture-conversation") {
+      values["capture-conversation"] = true;
     } else if (!arg.startsWith("-")) {
       positionals.push(arg);
     }
@@ -336,6 +338,7 @@ Options:
       --dev-server-port   Port for dev server (default: 4000, auto-increments for concurrent evals)
       --with-hooks <name> Use eval hooks from scripts/eval-hooks/<name>-pre.sh and <name>-post.sh
       --with-visual-diff  Enable visual regression testing with screenshot comparison
+      --capture-conversation  [Claude Code only] Capture full conversation with tool calls to JSONL
 
 Examples:
   # Run all evals with LLMs
@@ -1506,6 +1509,7 @@ async function main() {
           : undefined,
         hooks,
         visualDiff: values["with-visual-diff"] || false,
+        captureConversation: values["capture-conversation"] || false,
       };
 
       if (values.all) {


### PR DESCRIPTION
adds `--capture-conversation`, which records the full agentic loop by CC, including tool calls.