### PR TITLE
[bugfix] regex was redundant and didn't catch edge cases

### DIFF
--- a/evals/004-search-params/input/app/page.test.tsx
+++ b/evals/004-search-params/input/app/page.test.tsx
@@ -31,8 +31,6 @@ test('Page reads search params and forwards to Client component', () => {
   // Should render Client component with name prop
   expect(pageContent).toMatch(/<Client.*name.*=/);
   
-  // Should pass the name from searchParams to Client
-  expect(pageContent).toMatch(/name.*searchParams.*name|searchParams.*name.*name/);
 });
 
 test('Page extracts name parameter from searchParams', () => {


### PR DESCRIPTION
The regex didn't capture cases where the name prop was passed directly. 