### PR TITLE
Update GLM 5.1 OpenCode experiments to use Vercel provider with agentOptions

### DIFF
--- a/experiments/glm-5.1-opencode--agents-md.ts
+++ b/experiments/glm-5.1-opencode--agents-md.ts
@@ -2,7 +2,18 @@ import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   agent: 'vercel-ai-gateway/opencode',
-  model: 'ai-gateway/zai/glm-5.1',
+  model: 'vercel/zai/glm-5.1',
+  agentOptions: {
+    binaryUrl:
+      'https://ymdea60kblwwhidh.public.blob.vercel-storage.com/opencode-linux-x64-RCtfS54uaTwa5i9C3bpzguLy3jEBP6',
+    extraProviders: {
+      vercel: {
+        models: {
+          'zai/glm-5.1': { name: 'GLM 5.1' },
+        },
+      },
+    },
+  },
   scripts: ['build'],
   runs: 4,
   earlyExit: true,

--- a/experiments/glm-5.1-opencode.ts
+++ b/experiments/glm-5.1-opencode.ts
@@ -2,7 +2,18 @@ import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   agent: 'vercel-ai-gateway/opencode',
-  model: 'ai-gateway/zai/glm-5.1',
+  model: 'vercel/zai/glm-5.1',
+  agentOptions: {
+    binaryUrl:
+      'https://ymdea60kblwwhidh.public.blob.vercel-storage.com/opencode-linux-x64-RCtfS54uaTwa5i9C3bpzguLy3jEBP6',
+    extraProviders: {
+      vercel: {
+        models: {
+          'zai/glm-5.1': { name: 'GLM 5.1' },
+        },
+      },
+    },
+  },
   scripts: ['build'],
   runs: 4,
   earlyExit: true,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "typescript": "^5.6.0"
   },
   "dependencies": {
-    "@vercel/agent-eval": "^0.9.5"
+    "@vercel/agent-eval": "^0.11.0"
   },
   "packageManager": "pnpm@10.29.2+sha512.bef43fa759d91fd2da4b319a5a0d13ef7a45bb985a3d7342058470f9d2051a3ba8674e629672654686ef9443ad13a82da2beb9eeb3e0221c87b8154fff9d74b8"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@vercel/agent-eval':
-        specifier: ^0.9.5
-        version: 0.9.5
+        specifier: ^0.11.0
+        version: 0.11.0
     devDependencies:
       tsx:
         specifier: ^4.19.0
@@ -273,8 +273,8 @@ packages:
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
-  '@vercel/agent-eval@0.9.5':
-    resolution: {integrity: sha512-wSs0K39zZFQDNniG0UNeZMy3GgVDSuTyhVKZVqxm33nu3sq2KJjOSJCpvoFaXKUWkk2Ea3DTaxJsVgp8b1Xq5w==}
+  '@vercel/agent-eval@0.11.0':
+    resolution: {integrity: sha512-9H5EpESZ8vUyaV26WteZi7NjabXttdjZFZBgCs2P+yTgcVAo/kqqIdtBBaeEYpyvOrEkR+/4V7qYTWdBdTeYBQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -950,7 +950,7 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
-  '@vercel/agent-eval@0.9.5':
+  '@vercel/agent-eval@0.11.0':
     dependencies:
       '@ai-sdk/anthropic': 1.2.12(zod@3.25.76)
       '@vercel/sandbox': 1.8.1


### PR DESCRIPTION
Switches the GLM 5.1 OpenCode experiment configs from the `ai-gateway` provider prefix to `vercel`, and adds `agentOptions` with a pinned binary URL and `extraProviders` config for the `zai/glm-5.1` model. Bumps `@vercel/agent-eval` from `0.9.5` to `0.11.0` to support the new `agentOptions` API.