### PR TITLE
Add EVAL_FILTER env var to all experiment configs

### DIFF
--- a/experiments/claude-opus-4.6--agents-md.ts
+++ b/experiments/claude-opus-4.6--agents-md.ts
@@ -4,6 +4,7 @@ import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   agent: 'claude-code',
+  evals: process.env.EVAL_FILTER ?? "*",
   model: 'claude-opus-4-6',
   scripts: ['build'],
   runs: 4,

--- a/experiments/claude-opus-4.6.ts
+++ b/experiments/claude-opus-4.6.ts
@@ -2,6 +2,7 @@ import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   agent: 'claude-code',
+  evals: process.env.EVAL_FILTER ?? "*",
   model: 'claude-opus-4-6',
   scripts: ['build'],
   runs: 4,

--- a/experiments/claude-opus-4.7--agents-md.ts
+++ b/experiments/claude-opus-4.7--agents-md.ts
@@ -2,6 +2,7 @@ import type { ExperimentConfig } from "@vercel/agent-eval";
 
 const config: ExperimentConfig = {
   agent: "claude-code",
+  evals: process.env.EVAL_FILTER ?? "*",
   model: "claude-opus-4-7",
   agentOptions: {
     cliPackage: "@anthropic-ai/claude-code@next",

--- a/experiments/claude-opus-4.7.ts
+++ b/experiments/claude-opus-4.7.ts
@@ -2,6 +2,7 @@ import type { ExperimentConfig } from "@vercel/agent-eval";
 
 const config: ExperimentConfig = {
   agent: "claude-code",
+  evals: process.env.EVAL_FILTER ?? "*",
   model: "claude-opus-4-7",
   agentOptions: {
     cliPackage: "@anthropic-ai/claude-code@next",

--- a/experiments/claude-sonnet-4.5--agents-md.ts
+++ b/experiments/claude-sonnet-4.5--agents-md.ts
@@ -4,6 +4,7 @@ import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   agent: 'claude-code',
+  evals: process.env.EVAL_FILTER ?? "*",
   model: 'claude-sonnet-4-5',
   scripts: ['build'],
   runs: 4,

--- a/experiments/claude-sonnet-4.5.ts
+++ b/experiments/claude-sonnet-4.5.ts
@@ -2,6 +2,7 @@ import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   agent: 'claude-code',
+  evals: process.env.EVAL_FILTER ?? "*",
   model: 'claude-sonnet-4-5',
   scripts: ['build'],
   runs: 4,

--- a/experiments/claude-sonnet-4.6--agents-md.ts
+++ b/experiments/claude-sonnet-4.6--agents-md.ts
@@ -4,6 +4,7 @@ import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   agent: 'claude-code',
+  evals: process.env.EVAL_FILTER ?? "*",
   model: 'claude-sonnet-4-6',
   scripts: ['build'],
   runs: 4,

--- a/experiments/claude-sonnet-4.6.ts
+++ b/experiments/claude-sonnet-4.6.ts
@@ -2,6 +2,7 @@ import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   agent: 'claude-code',
+  evals: process.env.EVAL_FILTER ?? "*",
   model: 'claude-sonnet-4-6',
   scripts: ['build'],
   runs: 4,

--- a/experiments/cursor-composer-1.5--agents-md.ts
+++ b/experiments/cursor-composer-1.5--agents-md.ts
@@ -4,6 +4,7 @@ import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   agent: 'cursor',
+  evals: process.env.EVAL_FILTER ?? "*",
   model: 'composer-1.5',
   scripts: ['build'],
   runs: 4,

--- a/experiments/cursor-composer-1.5.ts
+++ b/experiments/cursor-composer-1.5.ts
@@ -2,6 +2,7 @@ import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   agent: 'cursor',
+  evals: process.env.EVAL_FILTER ?? "*",
   model: 'composer-1.5',
   scripts: ['build'],
   runs: 4,

--- a/experiments/cursor-composer-2.0--agents-md.ts
+++ b/experiments/cursor-composer-2.0--agents-md.ts
@@ -4,6 +4,7 @@ import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   agent: 'cursor',
+  evals: process.env.EVAL_FILTER ?? "*",
   model: 'composer-2',
   scripts: ['build'],
   runs: 4,

--- a/experiments/cursor-composer-2.0.ts
+++ b/experiments/cursor-composer-2.0.ts
@@ -2,6 +2,7 @@ import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   agent: 'cursor',
+  evals: process.env.EVAL_FILTER ?? "*",
   model: 'composer-2',
   scripts: ['build'],
   runs: 4,

--- a/experiments/gemini-3-pro-preview--agents-md.ts
+++ b/experiments/gemini-3-pro-preview--agents-md.ts
@@ -2,6 +2,7 @@ import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   agent: 'gemini',
+  evals: process.env.EVAL_FILTER ?? "*",
   model: 'gemini-3-pro-preview',
   scripts: ['build'],
   runs: 4,

--- a/experiments/gemini-3-pro-preview-gemini-cli.ts
+++ b/experiments/gemini-3-pro-preview-gemini-cli.ts
@@ -2,6 +2,7 @@ import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   agent: 'gemini',
+  evals: process.env.EVAL_FILTER ?? "*",
   model: 'gemini-3-pro-preview',
   scripts: ['build'],
   runs: 4,

--- a/experiments/gemini-3.1-pro-preview--agents-md.ts
+++ b/experiments/gemini-3.1-pro-preview--agents-md.ts
@@ -2,6 +2,7 @@ import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   agent: 'gemini',
+  evals: process.env.EVAL_FILTER ?? "*",
   model: 'gemini-3.1-pro-preview',
   scripts: ['build'],
   runs: 4,

--- a/experiments/gemini-3.1-pro-preview.ts
+++ b/experiments/gemini-3.1-pro-preview.ts
@@ -2,6 +2,7 @@ import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   agent: 'gemini',
+  evals: process.env.EVAL_FILTER ?? "*",
   model: 'gemini-3.1-pro-preview',
   scripts: ['build'],
   runs: 4,

--- a/experiments/glm-5.1-opencode--agents-md.ts
+++ b/experiments/glm-5.1-opencode--agents-md.ts
@@ -2,6 +2,7 @@ import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   agent: 'vercel-ai-gateway/opencode',
+  evals: process.env.EVAL_FILTER ?? "*",
   model: 'vercel/zai/glm-5.1',
   agentOptions: {
     binaryUrl:

--- a/experiments/glm-5.1-opencode.ts
+++ b/experiments/glm-5.1-opencode.ts
@@ -2,6 +2,7 @@ import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   agent: 'vercel-ai-gateway/opencode',
+  evals: process.env.EVAL_FILTER ?? "*",
   model: 'vercel/zai/glm-5.1',
   agentOptions: {
     binaryUrl:

--- a/experiments/gpt-5.2-codex-xhigh--agents-md.ts
+++ b/experiments/gpt-5.2-codex-xhigh--agents-md.ts
@@ -2,6 +2,7 @@ import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   agent: 'codex',
+  evals: process.env.EVAL_FILTER ?? "*",
   model: 'gpt-5.2-codex?reasoningEffort=xhigh',
   scripts: ['build'],
   runs: 4,

--- a/experiments/gpt-5.2-codex-xhigh.ts
+++ b/experiments/gpt-5.2-codex-xhigh.ts
@@ -2,6 +2,7 @@ import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   agent: 'codex',
+  evals: process.env.EVAL_FILTER ?? "*",
   model: 'gpt-5.2-codex?reasoningEffort=xhigh',
   scripts: ['build'],
   runs: 4,

--- a/experiments/gpt-5.3-codex-xhigh--agents-md.ts
+++ b/experiments/gpt-5.3-codex-xhigh--agents-md.ts
@@ -2,6 +2,7 @@ import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   agent: 'codex',
+  evals: process.env.EVAL_FILTER ?? "*",
   model: 'gpt-5.3-codex?reasoningEffort=xhigh',
   scripts: ['build'],
   runs: 4,

--- a/experiments/gpt-5.3-codex-xhigh.ts
+++ b/experiments/gpt-5.3-codex-xhigh.ts
@@ -2,6 +2,7 @@ import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   agent: 'codex',
+  evals: process.env.EVAL_FILTER ?? "*",
   model: 'gpt-5.3-codex?reasoningEffort=xhigh',
   scripts: ['build'],
   runs: 4,

--- a/experiments/gpt-5.4-xhigh--agents-md.ts
+++ b/experiments/gpt-5.4-xhigh--agents-md.ts
@@ -2,6 +2,7 @@ import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   agent: 'vercel-ai-gateway/codex',
+  evals: process.env.EVAL_FILTER ?? "*",
   model: 'openai/gpt-5.4?reasoningEffort=xhigh',
   scripts: ['build'],
   runs: 4,

--- a/experiments/gpt-5.4-xhigh.ts
+++ b/experiments/gpt-5.4-xhigh.ts
@@ -2,6 +2,7 @@ import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   agent: 'vercel-ai-gateway/codex',
+  evals: process.env.EVAL_FILTER ?? "*",
   model: 'openai/gpt-5.4?reasoningEffort=xhigh',
   scripts: ['build'],
   runs: 4,

--- a/experiments/kimi-k2.5--agents-md.ts
+++ b/experiments/kimi-k2.5--agents-md.ts
@@ -2,6 +2,7 @@ import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   agent: 'vercel-ai-gateway/opencode',
+  evals: process.env.EVAL_FILTER ?? "*",
   model: 'vercel/moonshotai/kimi-k2.5',
   scripts: ['build'],
   runs: 4,

--- a/experiments/kimi-k2.5.ts
+++ b/experiments/kimi-k2.5.ts
@@ -2,6 +2,7 @@ import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   agent: 'vercel-ai-gateway/opencode',
+  evals: process.env.EVAL_FILTER ?? "*",
   model: 'vercel/moonshotai/kimi-k2.5',
   scripts: ['build'],
   runs: 4,

--- a/experiments/minimax-m2.7--agents-md.ts
+++ b/experiments/minimax-m2.7--agents-md.ts
@@ -2,6 +2,7 @@ import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   agent: 'vercel-ai-gateway/opencode',
+  evals: process.env.EVAL_FILTER ?? "*",
   model: 'vercel/minimax/minimax-m2.7',
   scripts: ['build'],
   runs: 4,

--- a/experiments/minimax-m2.7.ts
+++ b/experiments/minimax-m2.7.ts
@@ -2,6 +2,7 @@ import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   agent: 'vercel-ai-gateway/opencode',
+  evals: process.env.EVAL_FILTER ?? "*",
   model: 'vercel/minimax/minimax-m2.7',
   scripts: ['build'],
   runs: 4,


### PR DESCRIPTION
## Summary
- Every `experiments/*.ts` now reads `evals: process.env.EVAL_FILTER ?? "*"`, so a single eval (or glob) can be run without editing any config
- Default behavior unchanged — `EVAL_FILTER` unset means run everything, same as before

## Usage
```bash
# Re-run one eval across all experiments (force, skip cache):
EVAL_FILTER=agent-025-prefer-next-link npm run eval -- --force

# One eval for one experiment (single-experiment mode, no memoization):
EVAL_FILTER=agent-025-prefer-next-link npx agent-eval kimi-k2.6

# Glob / brace expansion (minimatch):
EVAL_FILTER='{agent-029-*,agent-030-*}' npx agent-eval minimax-m3
```

## Test plan
- [ ] `npm run eval -- --dry` shows the same set of experiments and evals as before
- [ ] `EVAL_FILTER=agent-025-prefer-next-link npm run eval -- --dry` narrows to a single eval per experiment
- [ ] An invalid filter (e.g. `EVAL_FILTER=does-not-exist`) errors clearly via the framework's existing `resolveEvalNames` validation