### PR TITLE
Export per-eval list cost for nextjs.org/evals

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ The runner automatically detects:
 
 Exports clean results to `agent-results.json`. Non-model failures (infra/timeout) are automatically deleted during eval runs, so only valid model results are exported.
 
+Each experiment also gets an `avgCostUsd`: the mean list cost per eval. Tokens are read from each run's `transcript-raw.jsonl` (handled per harness in `scripts/cost.ts`) and multiplied by the list prices in `MODEL_PRICING`. A model with no price entry, or whose runs carry no token usage, exports `null` and renders as N/A. Prices are a snapshot, so re-run the export to refresh them.
+
+### `npm run test:cost`
+
+Unit tests for the token extraction and pricing in `scripts/cost.ts`.
+
 ## Eval structure
 
 Each eval is a self-contained Next.js project in `evals/`:
@@ -67,7 +73,8 @@ evals/agent-031-proxy-middleware/
 
 1. Create a config in `experiments/` (e.g., `experiments/gpt-5.ts`)
 2. Add the display name to `MODEL_NAMES` in `scripts/export-results.ts`
-3. Run `npm run eval` — it will automatically run all evals for the new model
+3. Add the list price to `MODEL_PRICING` in `scripts/cost.ts` (or the cost column shows N/A)
+4. Run `npm run eval` — it will automatically run all evals for the new model
 
 ## Publishing to nextjs.org/evals
 

--- a/agent-results.json
+++ b/agent-results.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "exportedAt": "2026-07-18T00:05:22.093Z",
+    "exportedAt": "2026-07-20T20:31:48.225Z",
     "experiments": [
       {
         "name": "claude-fable-5",
@@ -382,7 +382,7 @@
           "newlyFailed": []
         },
         "avgDuration": 142.51699479166666,
-        "avgCostUsd": 0.09212520833333336
+        "avgCostUsd": 0.07334867500000002
       },
       {
         "name": "kimi-k2.5",
@@ -4851,7 +4851,7 @@
     "grok-4.5": [
       {
         "evalPath": "agent-000-app-router-migration-simple",
-        "costUsd": 0.114356,
+        "costUsd": 0.0904456,
         "result": {
           "success": true,
           "duration": 151021.25,
@@ -4861,7 +4861,7 @@
       },
       {
         "evalPath": "agent-021-avoid-fetch-in-effect",
-        "costUsd": 0.050132,
+        "costUsd": 0.0427592,
         "result": {
           "success": true,
           "duration": 144475,
@@ -4871,7 +4871,7 @@
       },
       {
         "evalPath": "agent-022-prefer-server-actions",
-        "costUsd": 0.075772,
+        "costUsd": 0.062844,
         "result": {
           "success": true,
           "duration": 203688,
@@ -4881,7 +4881,7 @@
       },
       {
         "evalPath": "agent-023-avoid-getserversideprops",
-        "costUsd": 0.152184,
+        "costUsd": 0.1267376,
         "result": {
           "success": true,
           "duration": 130937.99999999999,
@@ -4891,7 +4891,7 @@
       },
       {
         "evalPath": "agent-024-avoid-redundant-usestate",
-        "costUsd": 0.043178,
+        "costUsd": 0.03665,
         "result": {
           "success": true,
           "duration": 162554,
@@ -4901,7 +4901,7 @@
       },
       {
         "evalPath": "agent-025-prefer-next-link",
-        "costUsd": 0.060726,
+        "costUsd": 0.053686,
         "result": {
           "success": true,
           "duration": 117721,
@@ -4911,7 +4911,7 @@
       },
       {
         "evalPath": "agent-026-no-serial-await",
-        "costUsd": 0.09385,
+        "costUsd": 0.0827652,
         "result": {
           "success": true,
           "duration": 122710,
@@ -4921,7 +4921,7 @@
       },
       {
         "evalPath": "agent-027-prefer-next-image",
-        "costUsd": 0.0491,
+        "costUsd": 0.039909599999999996,
         "result": {
           "success": true,
           "duration": 117649,
@@ -4931,7 +4931,7 @@
       },
       {
         "evalPath": "agent-028-prefer-next-font",
-        "costUsd": 0.092778,
+        "costUsd": 0.0795428,
         "result": {
           "success": true,
           "duration": 120619,
@@ -4941,7 +4941,7 @@
       },
       {
         "evalPath": "agent-029-use-cache-directive",
-        "costUsd": 0.223886,
+        "costUsd": 0.1773068,
         "result": {
           "success": true,
           "duration": 141594.49999999997,
@@ -4951,7 +4951,7 @@
       },
       {
         "evalPath": "agent-030-app-router-migration-hard",
-        "costUsd": 0.290934,
+        "costUsd": 0.2317724,
         "result": {
           "success": true,
           "duration": 271551,
@@ -4961,7 +4961,7 @@
       },
       {
         "evalPath": "agent-031-proxy-middleware",
-        "costUsd": 0.13014,
+        "costUsd": 0.09622,
         "result": {
           "success": true,
           "duration": 120730,
@@ -4971,7 +4971,7 @@
       },
       {
         "evalPath": "agent-032-use-cache-directive",
-        "costUsd": 0.142538,
+        "costUsd": 0.10977,
         "result": {
           "success": true,
           "duration": 135641,
@@ -4981,7 +4981,7 @@
       },
       {
         "evalPath": "agent-033-forbidden-auth",
-        "costUsd": 0.120212,
+        "costUsd": 0.1009608,
         "result": {
           "success": true,
           "duration": 130305,
@@ -4991,7 +4991,7 @@
       },
       {
         "evalPath": "agent-034-async-cookies",
-        "costUsd": 0.083116,
+        "costUsd": 0.0661688,
         "result": {
           "success": true,
           "duration": 247378,
@@ -5001,7 +5001,7 @@
       },
       {
         "evalPath": "agent-035-connection-dynamic",
-        "costUsd": 0.078468,
+        "costUsd": 0.0568616,
         "result": {
           "success": true,
           "duration": 108328,
@@ -5011,7 +5011,7 @@
       },
       {
         "evalPath": "agent-036-after-response",
-        "costUsd": 0.108882,
+        "costUsd": 0.08663560000000001,
         "result": {
           "success": true,
           "duration": 105176,
@@ -5021,7 +5021,7 @@
       },
       {
         "evalPath": "agent-037-updatetag-cache",
-        "costUsd": 0.07492,
+        "costUsd": 0.0584848,
         "result": {
           "success": true,
           "duration": 223980,
@@ -5031,7 +5031,7 @@
       },
       {
         "evalPath": "agent-038-refresh-settings",
-        "costUsd": 0.1238,
+        "costUsd": 0.09494879999999999,
         "result": {
           "success": true,
           "duration": 109265,
@@ -5041,7 +5041,7 @@
       },
       {
         "evalPath": "agent-039-indirect-proxy",
-        "costUsd": 0.07594,
+        "costUsd": 0.05965839999999999,
         "result": {
           "success": true,
           "duration": 109964,
@@ -5051,7 +5051,7 @@
       },
       {
         "evalPath": "agent-040-instant",
-        "costUsd": 0.1171045,
+        "costUsd": 0.09092209999999999,
         "result": {
           "success": false,
           "duration": 141459.25,
@@ -5061,7 +5061,7 @@
       },
       {
         "evalPath": "agent-041-optimize-ppr-shell",
-        "costUsd": 0.240982,
+        "costUsd": 0.1958236,
         "result": {
           "success": true,
           "duration": 143492,
@@ -5071,7 +5071,7 @@
       },
       {
         "evalPath": "agent-042-enable-ppr",
-        "costUsd": 0.054948,
+        "costUsd": 0.04250639999999999,
         "result": {
           "success": true,
           "duration": 110151,
@@ -5081,7 +5081,7 @@
       },
       {
         "evalPath": "agent-043-view-transitions",
-        "costUsd": 0.190736,
+        "costUsd": 0.14726720000000001,
         "result": {
           "success": true,
           "duration": 174543,

--- a/agent-results.json
+++ b/agent-results.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "exportedAt": "2026-07-17T03:26:39.000Z",
+    "exportedAt": "2026-07-18T00:05:22.093Z",
     "experiments": [
       {
         "name": "claude-fable-5",
@@ -16,7 +16,8 @@
           ],
           "newlyFailed": []
         },
-        "avgDuration": 233.927546875
+        "avgDuration": 233.927546875,
+        "avgCostUsd": 1.1343216831597223
       },
       {
         "name": "claude-opus-4.6",
@@ -36,7 +37,8 @@
           ],
           "newlyFailed": []
         },
-        "avgDuration": 189.27152173913043
+        "avgDuration": 189.27152173913043,
+        "avgCostUsd": 0.2041845901268116
       },
       {
         "name": "claude-opus-4.7",
@@ -56,7 +58,8 @@
           ],
           "newlyFailed": []
         },
-        "avgDuration": 142.47733695652173
+        "avgDuration": 142.47733695652173,
+        "avgCostUsd": 0.44537971150362304
       },
       {
         "name": "claude-opus-4.8",
@@ -73,7 +76,8 @@
           ],
           "newlyFailed": []
         },
-        "avgDuration": 165.910115942029
+        "avgDuration": 165.910115942029,
+        "avgCostUsd": 0.34813750860507253
       },
       {
         "name": "claude-sonnet-4.5",
@@ -96,7 +100,8 @@
           ],
           "newlyFailed": []
         },
-        "avgDuration": 150.53117934782608
+        "avgDuration": 150.53117934782608,
+        "avgCostUsd": 0.1301018894021739
       },
       {
         "name": "claude-sonnet-4.6",
@@ -120,7 +125,8 @@
           ],
           "newlyFailed": []
         },
-        "avgDuration": 157.50300543478264
+        "avgDuration": 157.50300543478264,
+        "avgCostUsd": 0.1397931179347826
       },
       {
         "name": "cursor-composer-1.5",
@@ -143,7 +149,8 @@
             "agent-041-optimize-ppr-shell"
           ]
         },
-        "avgDuration": 119.20196376811593
+        "avgDuration": 119.20196376811593,
+        "avgCostUsd": null
       },
       {
         "name": "cursor-composer-2.0",
@@ -162,7 +169,8 @@
           ],
           "newlyFailed": []
         },
-        "avgDuration": 115.52013586956522
+        "avgDuration": 115.52013586956522,
+        "avgCostUsd": 0.037874901086956514
       },
       {
         "name": "cursor-composer-2.5",
@@ -178,7 +186,8 @@
           ],
           "newlyFailed": []
         },
-        "avgDuration": 149.81890579710148
+        "avgDuration": 149.81890579710148,
+        "avgCostUsd": 0.046202874094202914
       },
       {
         "name": "gemini-3-pro-preview-gemini-cli",
@@ -197,7 +206,8 @@
           ],
           "newlyFailed": []
         },
-        "avgDuration": 260.36706521739137
+        "avgDuration": 260.36706521739137,
+        "avgCostUsd": 0.16534729927536232
       },
       {
         "name": "gemini-3.1-pro-preview",
@@ -216,7 +226,8 @@
           ],
           "newlyFailed": []
         },
-        "avgDuration": 247.44512499999996
+        "avgDuration": 247.44512499999996,
+        "avgCostUsd": 0.10952818369565215
       },
       {
         "name": "glm-5.1-opencode",
@@ -236,7 +247,8 @@
           ],
           "newlyFailed": []
         },
-        "avgDuration": 253.24236231884058
+        "avgDuration": 253.24236231884058,
+        "avgCostUsd": 0.07744346347826085
       },
       {
         "name": "glm-5.2",
@@ -253,7 +265,8 @@
           ],
           "newlyFailed": []
         },
-        "avgDuration": 285.1726847826087
+        "avgDuration": 285.1726847826087,
+        "avgCostUsd": 0.25259874666666665
       },
       {
         "name": "gpt-5.2-codex-xhigh",
@@ -276,7 +289,8 @@
             "agent-041-optimize-ppr-shell"
           ]
         },
-        "avgDuration": 149.59804710144928
+        "avgDuration": 149.59804710144928,
+        "avgCostUsd": 0.15025527644927536
       },
       {
         "name": "gpt-5.3-codex-xhigh",
@@ -293,11 +307,12 @@
           ],
           "newlyFailed": []
         },
-        "avgDuration": 178.57420471014493
+        "avgDuration": 178.57420471014493,
+        "avgCostUsd": 0.2325250432065217
       },
       {
         "name": "gpt-5.4-xhigh",
-        "timestamp": "2026-04-06T16:04:26.410Z",
+        "timestamp": "2026-07-17T19:18:24.998Z",
         "modelName": "GPT 5.4 (xhigh)",
         "agentHarness": "Codex",
         "docsImpact": {
@@ -309,7 +324,8 @@
           ],
           "newlyFailed": []
         },
-        "avgDuration": 220.41830434782608
+        "avgDuration": 227.97810326086957,
+        "avgCostUsd": 0.23759627380952383
       },
       {
         "name": "gpt-5.5-pro",
@@ -327,7 +343,8 @@
             "agent-030-app-router-migration-hard"
           ]
         },
-        "avgDuration": 771.631304347826
+        "avgDuration": 771.631304347826,
+        "avgCostUsd": 18.20529456521739
       },
       {
         "name": "gpt-5.6-sol-ultra",
@@ -345,7 +362,8 @@
             "agent-041-optimize-ppr-shell"
           ]
         },
-        "avgDuration": 231.8320555555556
+        "avgDuration": 231.8320555555556,
+        "avgCostUsd": 0.7407522673611108
       },
       {
         "name": "grok-4.5",
@@ -363,7 +381,8 @@
           ],
           "newlyFailed": []
         },
-        "avgDuration": 142.51699479166666
+        "avgDuration": 142.51699479166666,
+        "avgCostUsd": 0.09212520833333336
       },
       {
         "name": "kimi-k2.5",
@@ -390,7 +409,8 @@
             "agent-036-after-response"
           ]
         },
-        "avgDuration": 134.98967391304348
+        "avgDuration": 134.98967391304348,
+        "avgCostUsd": 0.01785406793478261
       },
       {
         "name": "kimi-k2.6",
@@ -412,7 +432,8 @@
           ],
           "newlyFailed": []
         },
-        "avgDuration": 197.68763768115943
+        "avgDuration": 197.68763768115943,
+        "avgCostUsd": 0.05702877067028986
       },
       {
         "name": "kimi-k2.7-code",
@@ -432,7 +453,8 @@
           ],
           "newlyFailed": []
         },
-        "avgDuration": 207.71883333333332
+        "avgDuration": 207.71883333333332,
+        "avgCostUsd": 0.060012581557971026
       },
       {
         "name": "kimi-k3",
@@ -448,7 +470,8 @@
           ],
           "newlyFailed": []
         },
-        "avgDuration": 199.89212499999996
+        "avgDuration": 199.89212499999996,
+        "avgCostUsd": 0.14063547604166668
       },
       {
         "name": "minimax-m2.7",
@@ -466,7 +489,8 @@
           ],
           "newlyFailed": []
         },
-        "avgDuration": 293.14428442028986
+        "avgDuration": 293.14428442028986,
+        "avgCostUsd": 0.02593042744565217
       },
       {
         "name": "minimax-m3",
@@ -486,7 +510,8 @@
           ],
           "newlyFailed": []
         },
-        "avgDuration": 181.87965760869565
+        "avgDuration": 181.87965760869565,
+        "avgCostUsd": 0.031964610108695654
       }
     ]
   },
@@ -494,6 +519,7 @@
     "claude-fable-5": [
       {
         "evalPath": "agent-000-app-router-migration-simple",
+        "costUsd": 1.7358515,
         "result": {
           "success": true,
           "duration": 249220,
@@ -503,6 +529,7 @@
       },
       {
         "evalPath": "agent-021-avoid-fetch-in-effect",
+        "costUsd": 0.9525155,
         "result": {
           "success": true,
           "duration": 203678,
@@ -512,6 +539,7 @@
       },
       {
         "evalPath": "agent-022-prefer-server-actions",
+        "costUsd": 0.8876915,
         "result": {
           "success": true,
           "duration": 196876,
@@ -521,6 +549,7 @@
       },
       {
         "evalPath": "agent-023-avoid-getserversideprops",
+        "costUsd": 1.7377285,
         "result": {
           "success": true,
           "duration": 228400,
@@ -530,6 +559,7 @@
       },
       {
         "evalPath": "agent-024-avoid-redundant-usestate",
+        "costUsd": 0.645378,
         "result": {
           "success": true,
           "duration": 179358,
@@ -539,6 +569,7 @@
       },
       {
         "evalPath": "agent-025-prefer-next-link",
+        "costUsd": 0.5051165,
         "result": {
           "success": true,
           "duration": 172549,
@@ -548,6 +579,7 @@
       },
       {
         "evalPath": "agent-026-no-serial-await",
+        "costUsd": 1.3416625,
         "result": {
           "success": true,
           "duration": 239621,
@@ -557,6 +589,7 @@
       },
       {
         "evalPath": "agent-027-prefer-next-image",
+        "costUsd": 0.5915435,
         "result": {
           "success": true,
           "duration": 165657,
@@ -566,6 +599,7 @@
       },
       {
         "evalPath": "agent-028-prefer-next-font",
+        "costUsd": 1.090019,
         "result": {
           "success": true,
           "duration": 202248,
@@ -575,6 +609,7 @@
       },
       {
         "evalPath": "agent-029-use-cache-directive",
+        "costUsd": 2.53301,
         "result": {
           "success": true,
           "duration": 268016,
@@ -584,6 +619,7 @@
       },
       {
         "evalPath": "agent-030-app-router-migration-hard",
+        "costUsd": 7.199389,
         "result": {
           "success": true,
           "duration": 519977.99999999994,
@@ -593,6 +629,7 @@
       },
       {
         "evalPath": "agent-031-proxy-middleware",
+        "costUsd": 0.9514,
         "result": {
           "success": true,
           "duration": 255466,
@@ -602,6 +639,7 @@
       },
       {
         "evalPath": "agent-032-use-cache-directive",
+        "costUsd": 1.233635,
         "result": {
           "success": true,
           "duration": 189281,
@@ -611,6 +649,7 @@
       },
       {
         "evalPath": "agent-033-forbidden-auth",
+        "costUsd": 1.1073895,
         "result": {
           "success": true,
           "duration": 237697,
@@ -620,6 +659,7 @@
       },
       {
         "evalPath": "agent-034-async-cookies",
+        "costUsd": 1.0850265,
         "result": {
           "success": true,
           "duration": 169682,
@@ -629,6 +669,7 @@
       },
       {
         "evalPath": "agent-035-connection-dynamic",
+        "costUsd": 0.742752,
         "result": {
           "success": true,
           "duration": 190408,
@@ -638,6 +679,7 @@
       },
       {
         "evalPath": "agent-036-after-response",
+        "costUsd": 0.9111485,
         "result": {
           "success": true,
           "duration": 204442,
@@ -647,6 +689,7 @@
       },
       {
         "evalPath": "agent-037-updatetag-cache",
+        "costUsd": 1.00257,
         "result": {
           "success": true,
           "duration": 203175,
@@ -656,6 +699,7 @@
       },
       {
         "evalPath": "agent-038-refresh-settings",
+        "costUsd": 1.703825,
         "result": {
           "success": true,
           "duration": 295424,
@@ -665,6 +709,7 @@
       },
       {
         "evalPath": "agent-039-indirect-proxy",
+        "costUsd": 0.7011395,
         "result": {
           "success": true,
           "duration": 254910,
@@ -674,6 +719,7 @@
       },
       {
         "evalPath": "agent-040-instant",
+        "costUsd": 0.9119101249999999,
         "result": {
           "success": false,
           "duration": 162067.5,
@@ -683,6 +729,7 @@
       },
       {
         "evalPath": "agent-041-optimize-ppr-shell",
+        "costUsd": 2.4581195,
         "result": {
           "success": true,
           "duration": 250326,
@@ -692,6 +739,7 @@
       },
       {
         "evalPath": "agent-042-enable-ppr",
+        "costUsd": 0.6459835,
         "result": {
           "success": true,
           "duration": 155063,
@@ -701,6 +749,7 @@
       },
       {
         "evalPath": "agent-043-view-transitions",
+        "costUsd": 3.5398295,
         "result": {
           "success": true,
           "duration": 362550,
@@ -712,6 +761,7 @@
     "claude-opus-4.6": [
       {
         "evalPath": "agent-000-app-router-migration-simple",
+        "costUsd": 0.361673375,
         "result": {
           "success": true,
           "duration": 233960,
@@ -721,6 +771,7 @@
       },
       {
         "evalPath": "agent-021-avoid-fetch-in-effect",
+        "costUsd": 0.17965025,
         "result": {
           "success": true,
           "duration": 197582,
@@ -730,6 +781,7 @@
       },
       {
         "evalPath": "agent-022-prefer-server-actions",
+        "costUsd": 0.20431525,
         "result": {
           "success": true,
           "duration": 183786,
@@ -739,6 +791,7 @@
       },
       {
         "evalPath": "agent-023-avoid-getserversideprops",
+        "costUsd": 0.25170525,
         "result": {
           "success": true,
           "duration": 190971,
@@ -748,6 +801,7 @@
       },
       {
         "evalPath": "agent-024-avoid-redundant-usestate",
+        "costUsd": 0.089499,
         "result": {
           "success": true,
           "duration": 156342,
@@ -757,6 +811,7 @@
       },
       {
         "evalPath": "agent-025-prefer-next-link",
+        "costUsd": 0.0486505,
         "result": {
           "success": true,
           "duration": 162254,
@@ -766,6 +821,7 @@
       },
       {
         "evalPath": "agent-026-no-serial-await",
+        "costUsd": 0.32122,
         "result": {
           "success": true,
           "duration": 224397,
@@ -775,6 +831,7 @@
       },
       {
         "evalPath": "agent-027-prefer-next-image",
+        "costUsd": 0.0558215,
         "result": {
           "success": true,
           "duration": 178210,
@@ -784,6 +841,7 @@
       },
       {
         "evalPath": "agent-028-prefer-next-font",
+        "costUsd": 0.1199315,
         "result": {
           "success": true,
           "duration": 155622,
@@ -793,6 +851,7 @@
       },
       {
         "evalPath": "agent-029-use-cache-directive",
+        "costUsd": 0.287252,
         "result": {
           "success": true,
           "duration": 237007,
@@ -802,6 +861,7 @@
       },
       {
         "evalPath": "agent-030-app-router-migration-hard",
+        "costUsd": 0.615002,
         "result": {
           "success": true,
           "duration": 362022,
@@ -811,6 +871,7 @@
       },
       {
         "evalPath": "agent-031-proxy-middleware",
+        "costUsd": 0.32581225,
         "result": {
           "success": true,
           "duration": 146556,
@@ -820,6 +881,7 @@
       },
       {
         "evalPath": "agent-032-use-cache-directive",
+        "costUsd": 0.148713,
         "result": {
           "success": true,
           "duration": 219432,
@@ -829,6 +891,7 @@
       },
       {
         "evalPath": "agent-033-forbidden-auth",
+        "costUsd": 0.305967,
         "result": {
           "success": true,
           "duration": 242428,
@@ -838,6 +901,7 @@
       },
       {
         "evalPath": "agent-034-async-cookies",
+        "costUsd": 0.133402,
         "result": {
           "success": true,
           "duration": 148042,
@@ -847,6 +911,7 @@
       },
       {
         "evalPath": "agent-035-connection-dynamic",
+        "costUsd": 0.121361,
         "result": {
           "success": true,
           "duration": 174014,
@@ -856,6 +921,7 @@
       },
       {
         "evalPath": "agent-036-after-response",
+        "costUsd": 0.1566875,
         "result": {
           "success": true,
           "duration": 201937,
@@ -865,6 +931,7 @@
       },
       {
         "evalPath": "agent-037-updatetag-cache",
+        "costUsd": 0.249837,
         "result": {
           "success": true,
           "duration": 234042,
@@ -874,6 +941,7 @@
       },
       {
         "evalPath": "agent-038-refresh-settings",
+        "costUsd": 0.34188875,
         "result": {
           "success": true,
           "duration": 223518,
@@ -883,6 +951,7 @@
       },
       {
         "evalPath": "agent-039-indirect-proxy",
+        "costUsd": 0.33670425,
         "result": {
           "success": true,
           "duration": 148397,
@@ -902,6 +971,7 @@
       },
       {
         "evalPath": "agent-041-optimize-ppr-shell",
+        "costUsd": 0.32415775,
         "result": {
           "success": true,
           "duration": 154948,
@@ -911,6 +981,7 @@
       },
       {
         "evalPath": "agent-042-enable-ppr",
+        "costUsd": 0.30473325,
         "result": {
           "success": true,
           "duration": 120661,
@@ -920,6 +991,7 @@
       },
       {
         "evalPath": "agent-043-view-transitions",
+        "costUsd": 0.32777275,
         "result": {
           "success": true,
           "duration": 183241,
@@ -931,6 +1003,7 @@
     "claude-opus-4.7": [
       {
         "evalPath": "agent-000-app-router-migration-simple",
+        "costUsd": 0.98342225,
         "result": {
           "success": true,
           "duration": 182984,
@@ -940,6 +1013,7 @@
       },
       {
         "evalPath": "agent-021-avoid-fetch-in-effect",
+        "costUsd": 0.60395175,
         "result": {
           "success": true,
           "duration": 149875,
@@ -949,6 +1023,7 @@
       },
       {
         "evalPath": "agent-022-prefer-server-actions",
+        "costUsd": 0.4147955,
         "result": {
           "success": true,
           "duration": 140812,
@@ -958,6 +1033,7 @@
       },
       {
         "evalPath": "agent-023-avoid-getserversideprops",
+        "costUsd": 0.46016025,
         "result": {
           "success": true,
           "duration": 142322.50000000003,
@@ -967,6 +1043,7 @@
       },
       {
         "evalPath": "agent-024-avoid-redundant-usestate",
+        "costUsd": 0.19371825,
         "result": {
           "success": true,
           "duration": 124174,
@@ -976,6 +1053,7 @@
       },
       {
         "evalPath": "agent-025-prefer-next-link",
+        "costUsd": 0.31239175,
         "result": {
           "success": true,
           "duration": 128773,
@@ -985,6 +1063,7 @@
       },
       {
         "evalPath": "agent-026-no-serial-await",
+        "costUsd": 0.36740225,
         "result": {
           "success": true,
           "duration": 129235.99999999999,
@@ -994,6 +1073,7 @@
       },
       {
         "evalPath": "agent-027-prefer-next-image",
+        "costUsd": 0.3807795,
         "result": {
           "success": true,
           "duration": 132680,
@@ -1003,6 +1083,7 @@
       },
       {
         "evalPath": "agent-028-prefer-next-font",
+        "costUsd": 0.5374115,
         "result": {
           "success": true,
           "duration": 131940,
@@ -1012,6 +1093,7 @@
       },
       {
         "evalPath": "agent-029-use-cache-directive",
+        "costUsd": 1.19537325,
         "result": {
           "success": true,
           "duration": 190150,
@@ -1021,6 +1103,7 @@
       },
       {
         "evalPath": "agent-030-app-router-migration-hard",
+        "costUsd": 1.8502486666666667,
         "result": {
           "success": true,
           "duration": 217091.99999999997,
@@ -1030,6 +1113,7 @@
       },
       {
         "evalPath": "agent-031-proxy-middleware",
+        "costUsd": 0.268455,
         "result": {
           "success": true,
           "duration": 110883,
@@ -1039,6 +1123,7 @@
       },
       {
         "evalPath": "agent-032-use-cache-directive",
+        "costUsd": 0.45547,
         "result": {
           "success": true,
           "duration": 136396,
@@ -1048,6 +1133,7 @@
       },
       {
         "evalPath": "agent-033-forbidden-auth",
+        "costUsd": 0.27448,
         "result": {
           "success": true,
           "duration": 138275,
@@ -1057,6 +1143,7 @@
       },
       {
         "evalPath": "agent-034-async-cookies",
+        "costUsd": 0.22899175,
         "result": {
           "success": true,
           "duration": 109884,
@@ -1066,6 +1153,7 @@
       },
       {
         "evalPath": "agent-035-connection-dynamic",
+        "costUsd": 0.230846,
         "result": {
           "success": true,
           "duration": 109757,
@@ -1075,6 +1163,7 @@
       },
       {
         "evalPath": "agent-036-after-response",
+        "costUsd": 0.2857695,
         "result": {
           "success": true,
           "duration": 113703,
@@ -1084,6 +1173,7 @@
       },
       {
         "evalPath": "agent-037-updatetag-cache",
+        "costUsd": 0.29420250000000003,
         "result": {
           "success": true,
           "duration": 132921.5,
@@ -1093,6 +1183,7 @@
       },
       {
         "evalPath": "agent-038-refresh-settings",
+        "costUsd": 0.33036675,
         "result": {
           "success": true,
           "duration": 145687,
@@ -1102,6 +1193,7 @@
       },
       {
         "evalPath": "agent-039-indirect-proxy",
+        "costUsd": 0.284076,
         "result": {
           "success": true,
           "duration": 113149,
@@ -1121,6 +1213,7 @@
       },
       {
         "evalPath": "agent-041-optimize-ppr-shell",
+        "costUsd": 0.9623195625000001,
         "result": {
           "success": true,
           "duration": 262254.25,
@@ -1130,6 +1223,7 @@
       },
       {
         "evalPath": "agent-042-enable-ppr",
+        "costUsd": 0.251008,
         "result": {
           "success": true,
           "duration": 106589,
@@ -1139,6 +1233,7 @@
       },
       {
         "evalPath": "agent-043-view-transitions",
+        "costUsd": 1.0126195,
         "result": {
           "success": true,
           "duration": 208734,
@@ -1150,6 +1245,7 @@
     "claude-opus-4.8": [
       {
         "evalPath": "agent-000-app-router-migration-simple",
+        "costUsd": 0.6755445,
         "result": {
           "success": true,
           "duration": 199438,
@@ -1159,6 +1255,7 @@
       },
       {
         "evalPath": "agent-021-avoid-fetch-in-effect",
+        "costUsd": 0.2803005,
         "result": {
           "success": true,
           "duration": 162209,
@@ -1168,6 +1265,7 @@
       },
       {
         "evalPath": "agent-022-prefer-server-actions",
+        "costUsd": 0.17386925,
         "result": {
           "success": true,
           "duration": 136297,
@@ -1177,6 +1275,7 @@
       },
       {
         "evalPath": "agent-023-avoid-getserversideprops",
+        "costUsd": 0.4190545,
         "result": {
           "success": true,
           "duration": 161910,
@@ -1186,6 +1285,7 @@
       },
       {
         "evalPath": "agent-024-avoid-redundant-usestate",
+        "costUsd": 0.072679,
         "result": {
           "success": true,
           "duration": 119508,
@@ -1195,6 +1295,7 @@
       },
       {
         "evalPath": "agent-025-prefer-next-link",
+        "costUsd": 0.37035975,
         "result": {
           "success": true,
           "duration": 134375,
@@ -1204,6 +1305,7 @@
       },
       {
         "evalPath": "agent-026-no-serial-await",
+        "costUsd": 0.26983875,
         "result": {
           "success": true,
           "duration": 160027,
@@ -1213,6 +1315,7 @@
       },
       {
         "evalPath": "agent-027-prefer-next-image",
+        "costUsd": 0.3566765,
         "result": {
           "success": true,
           "duration": 135456,
@@ -1222,6 +1325,7 @@
       },
       {
         "evalPath": "agent-028-prefer-next-font",
+        "costUsd": 0.46650475,
         "result": {
           "success": true,
           "duration": 151726,
@@ -1231,6 +1335,7 @@
       },
       {
         "evalPath": "agent-029-use-cache-directive",
+        "costUsd": 0.5943499166666667,
         "result": {
           "success": true,
           "duration": 216462.3333333333,
@@ -1240,6 +1345,7 @@
       },
       {
         "evalPath": "agent-030-app-router-migration-hard",
+        "costUsd": 2.58572425,
         "result": {
           "success": true,
           "duration": 347721,
@@ -1249,6 +1355,7 @@
       },
       {
         "evalPath": "agent-031-proxy-middleware",
+        "costUsd": 0.26802425,
         "result": {
           "success": true,
           "duration": 133655,
@@ -1258,6 +1365,7 @@
       },
       {
         "evalPath": "agent-032-use-cache-directive",
+        "costUsd": 0.52408075,
         "result": {
           "success": true,
           "duration": 156981,
@@ -1267,6 +1375,7 @@
       },
       {
         "evalPath": "agent-033-forbidden-auth",
+        "costUsd": 0.2293265,
         "result": {
           "success": true,
           "duration": 147814,
@@ -1276,6 +1385,7 @@
       },
       {
         "evalPath": "agent-034-async-cookies",
+        "costUsd": 0.30622575,
         "result": {
           "success": true,
           "duration": 148871,
@@ -1285,6 +1395,7 @@
       },
       {
         "evalPath": "agent-035-connection-dynamic",
+        "costUsd": 0.2055755,
         "result": {
           "success": true,
           "duration": 140505,
@@ -1294,6 +1405,7 @@
       },
       {
         "evalPath": "agent-036-after-response",
+        "costUsd": 0.192439,
         "result": {
           "success": true,
           "duration": 130315,
@@ -1303,6 +1415,7 @@
       },
       {
         "evalPath": "agent-037-updatetag-cache",
+        "costUsd": 0.2602565,
         "result": {
           "success": true,
           "duration": 167505,
@@ -1312,6 +1425,7 @@
       },
       {
         "evalPath": "agent-038-refresh-settings",
+        "costUsd": 0.343726625,
         "result": {
           "success": true,
           "duration": 150417,
@@ -1321,6 +1435,7 @@
       },
       {
         "evalPath": "agent-039-indirect-proxy",
+        "costUsd": 0.207272,
         "result": {
           "success": true,
           "duration": 128000,
@@ -1340,6 +1455,7 @@
       },
       {
         "evalPath": "agent-041-optimize-ppr-shell",
+        "costUsd": 0.74045225,
         "result": {
           "success": true,
           "duration": 266524.6666666667,
@@ -1349,6 +1465,7 @@
       },
       {
         "evalPath": "agent-042-enable-ppr",
+        "costUsd": 0.3112335,
         "result": {
           "success": true,
           "duration": 160264,
@@ -1358,6 +1475,7 @@
       },
       {
         "evalPath": "agent-043-view-transitions",
+        "costUsd": 0.79367775,
         "result": {
           "success": true,
           "duration": 307623,
@@ -1369,6 +1487,7 @@
     "claude-sonnet-4.5": [
       {
         "evalPath": "agent-000-app-router-migration-simple",
+        "costUsd": 0.1466919,
         "result": {
           "success": true,
           "duration": 216667,
@@ -1378,6 +1497,7 @@
       },
       {
         "evalPath": "agent-021-avoid-fetch-in-effect",
+        "costUsd": 0.11334254999999999,
         "result": {
           "success": true,
           "duration": 173308,
@@ -1387,6 +1507,7 @@
       },
       {
         "evalPath": "agent-022-prefer-server-actions",
+        "costUsd": 0.04645755,
         "result": {
           "success": true,
           "duration": 141385,
@@ -1396,6 +1517,7 @@
       },
       {
         "evalPath": "agent-023-avoid-getserversideprops",
+        "costUsd": 0.21208515,
         "result": {
           "success": true,
           "duration": 184387,
@@ -1405,6 +1527,7 @@
       },
       {
         "evalPath": "agent-024-avoid-redundant-usestate",
+        "costUsd": 0.050438699999999996,
         "result": {
           "success": true,
           "duration": 128608,
@@ -1414,6 +1537,7 @@
       },
       {
         "evalPath": "agent-025-prefer-next-link",
+        "costUsd": 0.0628248,
         "result": {
           "success": true,
           "duration": 141647,
@@ -1423,6 +1547,7 @@
       },
       {
         "evalPath": "agent-026-no-serial-await",
+        "costUsd": 0.120315,
         "result": {
           "success": true,
           "duration": 169591,
@@ -1432,6 +1557,7 @@
       },
       {
         "evalPath": "agent-027-prefer-next-image",
+        "costUsd": 0.0519048,
         "result": {
           "success": true,
           "duration": 133844,
@@ -1441,6 +1567,7 @@
       },
       {
         "evalPath": "agent-028-prefer-next-font",
+        "costUsd": 0.03841845,
         "result": {
           "success": true,
           "duration": 132298,
@@ -1450,6 +1577,7 @@
       },
       {
         "evalPath": "agent-029-use-cache-directive",
+        "costUsd": 0.357438825,
         "result": {
           "success": false,
           "duration": 265694.75,
@@ -1459,6 +1587,7 @@
       },
       {
         "evalPath": "agent-030-app-router-migration-hard",
+        "costUsd": 0.64777785,
         "result": {
           "success": true,
           "duration": 351994,
@@ -1468,6 +1597,7 @@
       },
       {
         "evalPath": "agent-031-proxy-middleware",
+        "costUsd": 0.09101115,
         "result": {
           "success": true,
           "duration": 112745.25,
@@ -1477,6 +1607,7 @@
       },
       {
         "evalPath": "agent-032-use-cache-directive",
+        "costUsd": 0.13818885,
         "result": {
           "success": true,
           "duration": 69689.33333333333,
@@ -1486,6 +1617,7 @@
       },
       {
         "evalPath": "agent-033-forbidden-auth",
+        "costUsd": 0.19337534999999997,
         "result": {
           "success": true,
           "duration": 203124,
@@ -1495,6 +1627,7 @@
       },
       {
         "evalPath": "agent-034-async-cookies",
+        "costUsd": 0.10519604999999999,
         "result": {
           "success": true,
           "duration": 68386.33333333333,
@@ -1504,6 +1637,7 @@
       },
       {
         "evalPath": "agent-035-connection-dynamic",
+        "costUsd": 0.22772085,
         "result": {
           "success": true,
           "duration": 188283,
@@ -1513,6 +1647,7 @@
       },
       {
         "evalPath": "agent-036-after-response",
+        "costUsd": 0.12909389999999998,
         "result": {
           "success": true,
           "duration": 186441,
@@ -1522,6 +1657,7 @@
       },
       {
         "evalPath": "agent-037-updatetag-cache",
+        "costUsd": 0.13467479999999998,
         "result": {
           "success": true,
           "duration": 110984.66666666667,
@@ -1531,6 +1667,7 @@
       },
       {
         "evalPath": "agent-038-refresh-settings",
+        "costUsd": 0.14116019999999999,
         "result": {
           "success": false,
           "duration": 141960.75,
@@ -1540,6 +1677,7 @@
       },
       {
         "evalPath": "agent-039-indirect-proxy",
+        "costUsd": 0.07801214999999999,
         "result": {
           "success": false,
           "duration": 142300,
@@ -1559,6 +1697,7 @@
       },
       {
         "evalPath": "agent-041-optimize-ppr-shell",
+        "costUsd": 0.27122579999999996,
         "result": {
           "success": true,
           "duration": 195916,
@@ -1568,6 +1707,7 @@
       },
       {
         "evalPath": "agent-042-enable-ppr",
+        "costUsd": 0.19668329999999998,
         "result": {
           "success": true,
           "duration": 110917,
@@ -1577,6 +1717,7 @@
       },
       {
         "evalPath": "agent-043-view-transitions",
+        "costUsd": 0.27680190000000005,
         "result": {
           "success": true,
           "duration": 183114,
@@ -1588,6 +1729,7 @@
     "claude-sonnet-4.6": [
       {
         "evalPath": "agent-000-app-router-migration-simple",
+        "costUsd": 0.3438708,
         "result": {
           "success": true,
           "duration": 184531,
@@ -1597,6 +1739,7 @@
       },
       {
         "evalPath": "agent-021-avoid-fetch-in-effect",
+        "costUsd": 0.195735,
         "result": {
           "success": true,
           "duration": 160133,
@@ -1606,6 +1749,7 @@
       },
       {
         "evalPath": "agent-022-prefer-server-actions",
+        "costUsd": 0.06274289999999999,
         "result": {
           "success": true,
           "duration": 158229,
@@ -1615,6 +1759,7 @@
       },
       {
         "evalPath": "agent-023-avoid-getserversideprops",
+        "costUsd": 0.04744365,
         "result": {
           "success": true,
           "duration": 147640,
@@ -1624,6 +1769,7 @@
       },
       {
         "evalPath": "agent-024-avoid-redundant-usestate",
+        "costUsd": 0.048496649999999995,
         "result": {
           "success": true,
           "duration": 133060,
@@ -1633,6 +1779,7 @@
       },
       {
         "evalPath": "agent-025-prefer-next-link",
+        "costUsd": 0.030709649999999998,
         "result": {
           "success": true,
           "duration": 116431,
@@ -1642,6 +1789,7 @@
       },
       {
         "evalPath": "agent-026-no-serial-await",
+        "costUsd": 0.04554,
         "result": {
           "success": true,
           "duration": 168658,
@@ -1651,6 +1799,7 @@
       },
       {
         "evalPath": "agent-027-prefer-next-image",
+        "costUsd": 0.051103800000000005,
         "result": {
           "success": true,
           "duration": 127562,
@@ -1660,6 +1809,7 @@
       },
       {
         "evalPath": "agent-028-prefer-next-font",
+        "costUsd": 0.07991385000000001,
         "result": {
           "success": true,
           "duration": 123032,
@@ -1669,6 +1819,7 @@
       },
       {
         "evalPath": "agent-029-use-cache-directive",
+        "costUsd": 0.33144509999999994,
         "result": {
           "success": true,
           "duration": 229788,
@@ -1678,6 +1829,7 @@
       },
       {
         "evalPath": "agent-030-app-router-migration-hard",
+        "costUsd": 0.76377285,
         "result": {
           "success": true,
           "duration": 355793,
@@ -1687,6 +1839,7 @@
       },
       {
         "evalPath": "agent-031-proxy-middleware",
+        "costUsd": 0.131145,
         "result": {
           "success": true,
           "duration": 107334,
@@ -1696,6 +1849,7 @@
       },
       {
         "evalPath": "agent-032-use-cache-directive",
+        "costUsd": 0.2297319,
         "result": {
           "success": true,
           "duration": 137826,
@@ -1705,6 +1859,7 @@
       },
       {
         "evalPath": "agent-033-forbidden-auth",
+        "costUsd": 0.19487895,
         "result": {
           "success": true,
           "duration": 157057,
@@ -1714,6 +1869,7 @@
       },
       {
         "evalPath": "agent-034-async-cookies",
+        "costUsd": 0.09880305,
         "result": {
           "success": true,
           "duration": 106268,
@@ -1723,6 +1879,7 @@
       },
       {
         "evalPath": "agent-035-connection-dynamic",
+        "costUsd": 0.13285575,
         "result": {
           "success": true,
           "duration": 104075,
@@ -1732,6 +1889,7 @@
       },
       {
         "evalPath": "agent-036-after-response",
+        "costUsd": 0.103056,
         "result": {
           "success": true,
           "duration": 118736,
@@ -1741,6 +1899,7 @@
       },
       {
         "evalPath": "agent-037-updatetag-cache",
+        "costUsd": 0.20068755,
         "result": {
           "success": true,
           "duration": 166702,
@@ -1750,6 +1909,7 @@
       },
       {
         "evalPath": "agent-038-refresh-settings",
+        "costUsd": 0.15145679999999997,
         "result": {
           "success": true,
           "duration": 132884,
@@ -1759,6 +1919,7 @@
       },
       {
         "evalPath": "agent-039-indirect-proxy",
+        "costUsd": 0.1725138,
         "result": {
           "success": true,
           "duration": 128715,
@@ -1778,6 +1939,7 @@
       },
       {
         "evalPath": "agent-041-optimize-ppr-shell",
+        "costUsd": 0.32544585,
         "result": {
           "success": true,
           "duration": 219266,
@@ -1787,6 +1949,7 @@
       },
       {
         "evalPath": "agent-042-enable-ppr",
+        "costUsd": 0.0518283,
         "result": {
           "success": true,
           "duration": 112702,
@@ -1796,6 +1959,7 @@
       },
       {
         "evalPath": "agent-043-view-transitions",
+        "costUsd": 0.32813295,
         "result": {
           "success": true,
           "duration": 211903,
@@ -2026,6 +2190,7 @@
     "cursor-composer-2.0": [
       {
         "evalPath": "agent-000-app-router-migration-simple",
+        "costUsd": 0.0510334,
         "result": {
           "success": true,
           "duration": 160029,
@@ -2035,6 +2200,7 @@
       },
       {
         "evalPath": "agent-021-avoid-fetch-in-effect",
+        "costUsd": 0.0192396,
         "result": {
           "success": true,
           "duration": 121197,
@@ -2044,6 +2210,7 @@
       },
       {
         "evalPath": "agent-022-prefer-server-actions",
+        "costUsd": 0.030144400000000002,
         "result": {
           "success": true,
           "duration": 86589,
@@ -2053,6 +2220,7 @@
       },
       {
         "evalPath": "agent-023-avoid-getserversideprops",
+        "costUsd": 0.037260100000000004,
         "result": {
           "success": true,
           "duration": 72920.5,
@@ -2062,6 +2230,7 @@
       },
       {
         "evalPath": "agent-024-avoid-redundant-usestate",
+        "costUsd": 0.020834,
         "result": {
           "success": true,
           "duration": 96327,
@@ -2071,6 +2240,7 @@
       },
       {
         "evalPath": "agent-025-prefer-next-link",
+        "costUsd": 0.0125801,
         "result": {
           "success": true,
           "duration": 87611,
@@ -2080,6 +2250,7 @@
       },
       {
         "evalPath": "agent-026-no-serial-await",
+        "costUsd": 0.038071,
         "result": {
           "success": true,
           "duration": 98286,
@@ -2089,6 +2260,7 @@
       },
       {
         "evalPath": "agent-027-prefer-next-image",
+        "costUsd": 0.0120911,
         "result": {
           "success": true,
           "duration": 90899,
@@ -2098,6 +2270,7 @@
       },
       {
         "evalPath": "agent-028-prefer-next-font",
+        "costUsd": 0.0277442,
         "result": {
           "success": true,
           "duration": 97296,
@@ -2107,6 +2280,7 @@
       },
       {
         "evalPath": "agent-029-use-cache-directive",
+        "costUsd": 0.0639716,
         "result": {
           "success": true,
           "duration": 109225.50000000001,
@@ -2116,6 +2290,7 @@
       },
       {
         "evalPath": "agent-030-app-router-migration-hard",
+        "costUsd": 0.13370310000000002,
         "result": {
           "success": true,
           "duration": 242347,
@@ -2125,6 +2300,7 @@
       },
       {
         "evalPath": "agent-031-proxy-middleware",
+        "costUsd": 0.049346466666666665,
         "result": {
           "success": false,
           "duration": 100318.75000000001,
@@ -2134,6 +2310,7 @@
       },
       {
         "evalPath": "agent-032-use-cache-directive",
+        "costUsd": 0.0255532,
         "result": {
           "success": true,
           "duration": 99186,
@@ -2143,6 +2320,7 @@
       },
       {
         "evalPath": "agent-033-forbidden-auth",
+        "costUsd": 0.0476868,
         "result": {
           "success": true,
           "duration": 146088,
@@ -2152,6 +2330,7 @@
       },
       {
         "evalPath": "agent-034-async-cookies",
+        "costUsd": 0.0222854,
         "result": {
           "success": true,
           "duration": 107813,
@@ -2161,6 +2340,7 @@
       },
       {
         "evalPath": "agent-035-connection-dynamic",
+        "costUsd": 0.028165950000000002,
         "result": {
           "success": true,
           "duration": 79284,
@@ -2170,6 +2350,7 @@
       },
       {
         "evalPath": "agent-036-after-response",
+        "costUsd": 0.0371702,
         "result": {
           "success": true,
           "duration": 116911,
@@ -2179,6 +2360,7 @@
       },
       {
         "evalPath": "agent-037-updatetag-cache",
+        "costUsd": 0.0396865,
         "result": {
           "success": true,
           "duration": 129419.99999999999,
@@ -2188,6 +2370,7 @@
       },
       {
         "evalPath": "agent-038-refresh-settings",
+        "costUsd": 0.035172699999999994,
         "result": {
           "success": true,
           "duration": 76109.5,
@@ -2197,6 +2380,7 @@
       },
       {
         "evalPath": "agent-039-indirect-proxy",
+        "costUsd": 0.0235086,
         "result": {
           "success": true,
           "duration": 64873.49999999999,
@@ -2216,6 +2400,7 @@
       },
       {
         "evalPath": "agent-041-optimize-ppr-shell",
+        "costUsd": 0.063448,
         "result": {
           "success": true,
           "duration": 207084,
@@ -2225,6 +2410,7 @@
       },
       {
         "evalPath": "agent-042-enable-ppr",
+        "costUsd": 0.0229822,
         "result": {
           "success": true,
           "duration": 117576,
@@ -2234,6 +2420,7 @@
       },
       {
         "evalPath": "agent-043-view-transitions",
+        "costUsd": 0.0332529,
         "result": {
           "success": true,
           "duration": 177292,
@@ -2245,6 +2432,7 @@
     "cursor-composer-2.5": [
       {
         "evalPath": "agent-000-app-router-migration-simple",
+        "costUsd": 0.0549936,
         "result": {
           "success": true,
           "duration": 158785,
@@ -2254,6 +2442,7 @@
       },
       {
         "evalPath": "agent-021-avoid-fetch-in-effect",
+        "costUsd": 0.0350509,
         "result": {
           "success": true,
           "duration": 128981,
@@ -2263,6 +2452,7 @@
       },
       {
         "evalPath": "agent-022-prefer-server-actions",
+        "costUsd": 0.0359064,
         "result": {
           "success": true,
           "duration": 146269,
@@ -2272,6 +2462,7 @@
       },
       {
         "evalPath": "agent-023-avoid-getserversideprops",
+        "costUsd": 0.0305178,
         "result": {
           "success": true,
           "duration": 123153,
@@ -2281,6 +2472,7 @@
       },
       {
         "evalPath": "agent-024-avoid-redundant-usestate",
+        "costUsd": 0.028853300000000002,
         "result": {
           "success": true,
           "duration": 127304,
@@ -2290,6 +2482,7 @@
       },
       {
         "evalPath": "agent-025-prefer-next-link",
+        "costUsd": 0.0238151,
         "result": {
           "success": true,
           "duration": 125841,
@@ -2299,6 +2492,7 @@
       },
       {
         "evalPath": "agent-026-no-serial-await",
+        "costUsd": 0.08101855,
         "result": {
           "success": true,
           "duration": 199286.99999999997,
@@ -2308,6 +2502,7 @@
       },
       {
         "evalPath": "agent-027-prefer-next-image",
+        "costUsd": 0.023484,
         "result": {
           "success": true,
           "duration": 107071,
@@ -2317,6 +2512,7 @@
       },
       {
         "evalPath": "agent-028-prefer-next-font",
+        "costUsd": 0.0371625,
         "result": {
           "success": true,
           "duration": 139562,
@@ -2326,6 +2522,7 @@
       },
       {
         "evalPath": "agent-029-use-cache-directive",
+        "costUsd": 0.10463639999999999,
         "result": {
           "success": true,
           "duration": 232339,
@@ -2335,6 +2532,7 @@
       },
       {
         "evalPath": "agent-030-app-router-migration-hard",
+        "costUsd": 0.0781379,
         "result": {
           "success": true,
           "duration": 229753,
@@ -2344,6 +2542,7 @@
       },
       {
         "evalPath": "agent-031-proxy-middleware",
+        "costUsd": 0.06606583333333334,
         "result": {
           "success": true,
           "duration": 133010.6666666667,
@@ -2353,6 +2552,7 @@
       },
       {
         "evalPath": "agent-032-use-cache-directive",
+        "costUsd": 0.039586300000000005,
         "result": {
           "success": true,
           "duration": 141029,
@@ -2362,6 +2562,7 @@
       },
       {
         "evalPath": "agent-033-forbidden-auth",
+        "costUsd": 0.0503196,
         "result": {
           "success": true,
           "duration": 158540,
@@ -2371,6 +2572,7 @@
       },
       {
         "evalPath": "agent-034-async-cookies",
+        "costUsd": 0.029934,
         "result": {
           "success": true,
           "duration": 120889,
@@ -2380,6 +2582,7 @@
       },
       {
         "evalPath": "agent-035-connection-dynamic",
+        "costUsd": 0.0275525,
         "result": {
           "success": true,
           "duration": 133342,
@@ -2389,6 +2592,7 @@
       },
       {
         "evalPath": "agent-036-after-response",
+        "costUsd": 0.0332315,
         "result": {
           "success": true,
           "duration": 133532,
@@ -2398,6 +2602,7 @@
       },
       {
         "evalPath": "agent-037-updatetag-cache",
+        "costUsd": 0.060923,
         "result": {
           "success": true,
           "duration": 160566,
@@ -2407,6 +2612,7 @@
       },
       {
         "evalPath": "agent-038-refresh-settings",
+        "costUsd": 0.05112270000000001,
         "result": {
           "success": true,
           "duration": 140237,
@@ -2416,6 +2622,7 @@
       },
       {
         "evalPath": "agent-039-indirect-proxy",
+        "costUsd": 0.0656305,
         "result": {
           "success": true,
           "duration": 147081,
@@ -2435,6 +2642,7 @@
       },
       {
         "evalPath": "agent-041-optimize-ppr-shell",
+        "costUsd": 0.0897073,
         "result": {
           "success": true,
           "duration": 159539,
@@ -2444,6 +2652,7 @@
       },
       {
         "evalPath": "agent-042-enable-ppr",
+        "costUsd": 0.028249,
         "result": {
           "success": true,
           "duration": 122187,
@@ -2453,6 +2662,7 @@
       },
       {
         "evalPath": "agent-043-view-transitions",
+        "costUsd": 0.06816520000000001,
         "result": {
           "success": true,
           "duration": 151045,
@@ -2464,6 +2674,7 @@
     "gemini-3-pro-preview-gemini-cli": [
       {
         "evalPath": "agent-000-app-router-migration-simple",
+        "costUsd": 0.0719894,
         "result": {
           "success": true,
           "duration": 188561,
@@ -2473,6 +2684,7 @@
       },
       {
         "evalPath": "agent-021-avoid-fetch-in-effect",
+        "costUsd": 0.098725,
         "result": {
           "success": true,
           "duration": 266739,
@@ -2482,6 +2694,7 @@
       },
       {
         "evalPath": "agent-022-prefer-server-actions",
+        "costUsd": 0.151831,
         "result": {
           "success": true,
           "duration": 320857,
@@ -2491,6 +2704,7 @@
       },
       {
         "evalPath": "agent-023-avoid-getserversideprops",
+        "costUsd": 0.1532278,
         "result": {
           "success": true,
           "duration": 274927,
@@ -2500,6 +2714,7 @@
       },
       {
         "evalPath": "agent-024-avoid-redundant-usestate",
+        "costUsd": 0.16872,
         "result": {
           "success": true,
           "duration": 144075.33333333334,
@@ -2509,6 +2724,7 @@
       },
       {
         "evalPath": "agent-025-prefer-next-link",
+        "costUsd": 0.1417098,
         "result": {
           "success": true,
           "duration": 284386,
@@ -2518,6 +2734,7 @@
       },
       {
         "evalPath": "agent-026-no-serial-await",
+        "costUsd": 0.16411479999999998,
         "result": {
           "success": true,
           "duration": 256766.00000000003,
@@ -2527,6 +2744,7 @@
       },
       {
         "evalPath": "agent-027-prefer-next-image",
+        "costUsd": 0.0680958,
         "result": {
           "success": true,
           "duration": 200674,
@@ -2536,6 +2754,7 @@
       },
       {
         "evalPath": "agent-028-prefer-next-font",
+        "costUsd": 0.0384392,
         "result": {
           "success": true,
           "duration": 158184,
@@ -2545,6 +2764,7 @@
       },
       {
         "evalPath": "agent-029-use-cache-directive",
+        "costUsd": 0.29529,
         "result": {
           "success": true,
           "duration": 383510,
@@ -2554,6 +2774,7 @@
       },
       {
         "evalPath": "agent-030-app-router-migration-hard",
+        "costUsd": 0.259729,
         "result": {
           "success": true,
           "duration": 414300.75,
@@ -2563,6 +2784,7 @@
       },
       {
         "evalPath": "agent-031-proxy-middleware",
+        "costUsd": 0.1943141,
         "result": {
           "success": true,
           "duration": 334930,
@@ -2572,6 +2794,7 @@
       },
       {
         "evalPath": "agent-032-use-cache-directive",
+        "costUsd": 0.2559066,
         "result": {
           "success": true,
           "duration": 414508.5,
@@ -2581,6 +2804,7 @@
       },
       {
         "evalPath": "agent-033-forbidden-auth",
+        "costUsd": 0.20675079999999998,
         "result": {
           "success": true,
           "duration": 345835,
@@ -2590,6 +2814,7 @@
       },
       {
         "evalPath": "agent-034-async-cookies",
+        "costUsd": 0.2028536,
         "result": {
           "success": true,
           "duration": 265170,
@@ -2599,6 +2824,7 @@
       },
       {
         "evalPath": "agent-035-connection-dynamic",
+        "costUsd": 0.310226,
         "result": {
           "success": true,
           "duration": 323664,
@@ -2608,6 +2834,7 @@
       },
       {
         "evalPath": "agent-036-after-response",
+        "costUsd": 0.22653379999999998,
         "result": {
           "success": true,
           "duration": 360935,
@@ -2617,6 +2844,7 @@
       },
       {
         "evalPath": "agent-037-updatetag-cache",
+        "costUsd": 0.302099,
         "result": {
           "success": false,
           "duration": 381380.25000000006,
@@ -2626,6 +2854,7 @@
       },
       {
         "evalPath": "agent-038-refresh-settings",
+        "costUsd": 0.1252198,
         "result": {
           "success": false,
           "duration": 380245,
@@ -2635,6 +2864,7 @@
       },
       {
         "evalPath": "agent-039-indirect-proxy",
+        "costUsd": 0.2399486,
         "result": {
           "success": true,
           "duration": 413241.3333333333,
@@ -2654,6 +2884,7 @@
       },
       {
         "evalPath": "agent-041-optimize-ppr-shell",
+        "costUsd": 0.21491506666666668,
         "result": {
           "success": false,
           "duration": 263120,
@@ -2663,6 +2894,7 @@
       },
       {
         "evalPath": "agent-042-enable-ppr",
+        "costUsd": 0.1370256,
         "result": {
           "success": true,
           "duration": 138369,
@@ -2672,6 +2904,7 @@
       },
       {
         "evalPath": "agent-043-view-transitions",
+        "costUsd": 0.23973260000000002,
         "result": {
           "success": true,
           "duration": 228932,
@@ -2683,6 +2916,7 @@
     "gemini-3.1-pro-preview": [
       {
         "evalPath": "agent-000-app-router-migration-simple",
+        "costUsd": 0.065598,
         "result": {
           "success": true,
           "duration": 344324,
@@ -2692,6 +2926,7 @@
       },
       {
         "evalPath": "agent-021-avoid-fetch-in-effect",
+        "costUsd": 0.1431022,
         "result": {
           "success": true,
           "duration": 251674.00000000003,
@@ -2701,6 +2936,7 @@
       },
       {
         "evalPath": "agent-022-prefer-server-actions",
+        "costUsd": 0.1125838,
         "result": {
           "success": true,
           "duration": 385207,
@@ -2710,6 +2946,7 @@
       },
       {
         "evalPath": "agent-023-avoid-getserversideprops",
+        "costUsd": 0.1510938,
         "result": {
           "success": true,
           "duration": 231496,
@@ -2719,6 +2956,7 @@
       },
       {
         "evalPath": "agent-024-avoid-redundant-usestate",
+        "costUsd": 0.028662200000000002,
         "result": {
           "success": true,
           "duration": 201988.33333333334,
@@ -2728,6 +2966,7 @@
       },
       {
         "evalPath": "agent-025-prefer-next-link",
+        "costUsd": 0.0729108,
         "result": {
           "success": true,
           "duration": 195057,
@@ -2737,6 +2976,7 @@
       },
       {
         "evalPath": "agent-026-no-serial-await",
+        "costUsd": 0.13842220000000002,
         "result": {
           "success": true,
           "duration": 285309.5,
@@ -2746,6 +2986,7 @@
       },
       {
         "evalPath": "agent-027-prefer-next-image",
+        "costUsd": 0.1317056,
         "result": {
           "success": true,
           "duration": 201744,
@@ -2755,6 +2996,7 @@
       },
       {
         "evalPath": "agent-028-prefer-next-font",
+        "costUsd": 0.144778,
         "result": {
           "success": true,
           "duration": 260037.74999999997,
@@ -2764,6 +3006,7 @@
       },
       {
         "evalPath": "agent-029-use-cache-directive",
+        "costUsd": 0.2957788,
         "result": {
           "success": true,
           "duration": 362522,
@@ -2773,6 +3016,7 @@
       },
       {
         "evalPath": "agent-030-app-router-migration-hard",
+        "costUsd": 0.2107466,
         "result": {
           "success": true,
           "duration": 486449,
@@ -2782,6 +3026,7 @@
       },
       {
         "evalPath": "agent-031-proxy-middleware",
+        "costUsd": 0.1090458,
         "result": {
           "success": true,
           "duration": 248394.5,
@@ -2791,6 +3036,7 @@
       },
       {
         "evalPath": "agent-032-use-cache-directive",
+        "costUsd": 0.14477720000000002,
         "result": {
           "success": true,
           "duration": 240485,
@@ -2800,6 +3046,7 @@
       },
       {
         "evalPath": "agent-033-forbidden-auth",
+        "costUsd": 0.23261720000000002,
         "result": {
           "success": true,
           "duration": 247206.66666666672,
@@ -2809,6 +3056,7 @@
       },
       {
         "evalPath": "agent-034-async-cookies",
+        "costUsd": 0.0744968,
         "result": {
           "success": true,
           "duration": 213808,
@@ -2818,6 +3066,7 @@
       },
       {
         "evalPath": "agent-035-connection-dynamic",
+        "costUsd": 0.066965,
         "result": {
           "success": true,
           "duration": 371268,
@@ -2827,6 +3076,7 @@
       },
       {
         "evalPath": "agent-036-after-response",
+        "costUsd": 0.1440774,
         "result": {
           "success": true,
           "duration": 285368,
@@ -2836,6 +3086,7 @@
       },
       {
         "evalPath": "agent-037-updatetag-cache",
+        "costUsd": 0.1646724,
         "result": {
           "success": true,
           "duration": 260789.99999999997,
@@ -2845,6 +3096,7 @@
       },
       {
         "evalPath": "agent-038-refresh-settings",
+        "costUsd": 0.1294158,
         "result": {
           "success": true,
           "duration": 285313.25,
@@ -2854,6 +3106,7 @@
       },
       {
         "evalPath": "agent-039-indirect-proxy",
+        "costUsd": 0.1660182,
         "result": {
           "success": true,
           "duration": 229554,
@@ -2873,6 +3126,7 @@
       },
       {
         "evalPath": "agent-041-optimize-ppr-shell",
+        "costUsd": 0.19379545,
         "result": {
           "success": false,
           "duration": 226308.49999999997,
@@ -2882,6 +3136,7 @@
       },
       {
         "evalPath": "agent-042-enable-ppr",
+        "costUsd": 0.10227860000000001,
         "result": {
           "success": true,
           "duration": 134785,
@@ -2891,6 +3146,7 @@
       },
       {
         "evalPath": "agent-043-view-transitions",
+        "costUsd": 0.261582,
         "result": {
           "success": true,
           "duration": 242920,
@@ -2902,6 +3158,7 @@
     "glm-5.1-opencode": [
       {
         "evalPath": "agent-000-app-router-migration-simple",
+        "costUsd": 0.08917364,
         "result": {
           "success": true,
           "duration": 273814,
@@ -2911,6 +3168,7 @@
       },
       {
         "evalPath": "agent-021-avoid-fetch-in-effect",
+        "costUsd": 0.07244832000000001,
         "result": {
           "success": true,
           "duration": 334252,
@@ -2920,6 +3178,7 @@
       },
       {
         "evalPath": "agent-022-prefer-server-actions",
+        "costUsd": 0.052133120000000005,
         "result": {
           "success": true,
           "duration": 268807,
@@ -2929,6 +3188,7 @@
       },
       {
         "evalPath": "agent-023-avoid-getserversideprops",
+        "costUsd": 0.025995640000000004,
         "result": {
           "success": true,
           "duration": 221483,
@@ -2938,6 +3198,7 @@
       },
       {
         "evalPath": "agent-024-avoid-redundant-usestate",
+        "costUsd": 0.049390800000000006,
         "result": {
           "success": true,
           "duration": 141729,
@@ -2947,6 +3208,7 @@
       },
       {
         "evalPath": "agent-025-prefer-next-link",
+        "costUsd": 0.01738348,
         "result": {
           "success": true,
           "duration": 128114,
@@ -2956,6 +3218,7 @@
       },
       {
         "evalPath": "agent-026-no-serial-await",
+        "costUsd": 0.05771666,
         "result": {
           "success": true,
           "duration": 184664.5,
@@ -2965,6 +3228,7 @@
       },
       {
         "evalPath": "agent-027-prefer-next-image",
+        "costUsd": 0.0335016,
         "result": {
           "success": true,
           "duration": 134095,
@@ -2974,6 +3238,7 @@
       },
       {
         "evalPath": "agent-028-prefer-next-font",
+        "costUsd": 0.09456052000000001,
         "result": {
           "success": true,
           "duration": 180927.5,
@@ -2983,6 +3248,7 @@
       },
       {
         "evalPath": "agent-029-use-cache-directive",
+        "costUsd": 0.20862288,
         "result": {
           "success": true,
           "duration": 310436,
@@ -2992,6 +3258,7 @@
       },
       {
         "evalPath": "agent-030-app-router-migration-hard",
+        "costUsd": 0.35997586666666664,
         "result": {
           "success": true,
           "duration": 395913.33333333343,
@@ -3001,6 +3268,7 @@
       },
       {
         "evalPath": "agent-031-proxy-middleware",
+        "costUsd": 0.07901592,
         "result": {
           "success": true,
           "duration": 177122,
@@ -3010,6 +3278,7 @@
       },
       {
         "evalPath": "agent-032-use-cache-directive",
+        "costUsd": 0.1507092,
         "result": {
           "success": true,
           "duration": 209961,
@@ -3019,6 +3288,7 @@
       },
       {
         "evalPath": "agent-033-forbidden-auth",
+        "costUsd": 0.06403984,
         "result": {
           "success": true,
           "duration": 254442,
@@ -3028,6 +3298,7 @@
       },
       {
         "evalPath": "agent-034-async-cookies",
+        "costUsd": 0.07664167999999999,
         "result": {
           "success": true,
           "duration": 153530,
@@ -3037,6 +3308,7 @@
       },
       {
         "evalPath": "agent-035-connection-dynamic",
+        "costUsd": 0.07344339999999999,
         "result": {
           "success": true,
           "duration": 159643,
@@ -3046,6 +3318,7 @@
       },
       {
         "evalPath": "agent-036-after-response",
+        "costUsd": 0.06860807999999999,
         "result": {
           "success": true,
           "duration": 164112,
@@ -3055,6 +3328,7 @@
       },
       {
         "evalPath": "agent-037-updatetag-cache",
+        "costUsd": 0.05591528,
         "result": {
           "success": true,
           "duration": 362944,
@@ -3064,6 +3338,7 @@
       },
       {
         "evalPath": "agent-038-refresh-settings",
+        "costUsd": 0.032313,
         "result": {
           "success": true,
           "duration": 300414,
@@ -3073,6 +3348,7 @@
       },
       {
         "evalPath": "agent-039-indirect-proxy",
+        "costUsd": 0.07472623999999999,
         "result": {
           "success": true,
           "duration": 149761,
@@ -3092,6 +3368,7 @@
       },
       {
         "evalPath": "agent-041-optimize-ppr-shell",
+        "costUsd": 0.127262,
         "result": {
           "success": true,
           "duration": 411322,
@@ -3101,6 +3378,7 @@
       },
       {
         "evalPath": "agent-042-enable-ppr",
+        "costUsd": 0.08529128,
         "result": {
           "success": true,
           "duration": 223728,
@@ -3110,6 +3388,7 @@
       },
       {
         "evalPath": "agent-043-view-transitions",
+        "costUsd": 0.27242520000000003,
         "result": {
           "success": true,
           "duration": 419452,
@@ -3121,6 +3400,7 @@
     "glm-5.2": [
       {
         "evalPath": "agent-000-app-router-migration-simple",
+        "costUsd": 0.35907907999999994,
         "result": {
           "success": true,
           "duration": 297875,
@@ -3130,6 +3410,7 @@
       },
       {
         "evalPath": "agent-021-avoid-fetch-in-effect",
+        "costUsd": 0.16370156,
         "result": {
           "success": true,
           "duration": 235065,
@@ -3139,6 +3420,7 @@
       },
       {
         "evalPath": "agent-022-prefer-server-actions",
+        "costUsd": 0.25404432,
         "result": {
           "success": true,
           "duration": 232464,
@@ -3148,6 +3430,7 @@
       },
       {
         "evalPath": "agent-023-avoid-getserversideprops",
+        "costUsd": 0.21607448,
         "result": {
           "success": true,
           "duration": 227544,
@@ -3157,6 +3440,7 @@
       },
       {
         "evalPath": "agent-024-avoid-redundant-usestate",
+        "costUsd": 0.06437775999999999,
         "result": {
           "success": true,
           "duration": 164497,
@@ -3166,6 +3450,7 @@
       },
       {
         "evalPath": "agent-025-prefer-next-link",
+        "costUsd": 0.08444236,
         "result": {
           "success": true,
           "duration": 171884,
@@ -3175,6 +3460,7 @@
       },
       {
         "evalPath": "agent-026-no-serial-await",
+        "costUsd": 0.2590896,
         "result": {
           "success": true,
           "duration": 261743,
@@ -3184,6 +3470,7 @@
       },
       {
         "evalPath": "agent-027-prefer-next-image",
+        "costUsd": 0.18436819999999998,
         "result": {
           "success": true,
           "duration": 198476,
@@ -3193,6 +3480,7 @@
       },
       {
         "evalPath": "agent-028-prefer-next-font",
+        "costUsd": 0.09560476,
         "result": {
           "success": true,
           "duration": 162906,
@@ -3202,6 +3490,7 @@
       },
       {
         "evalPath": "agent-029-use-cache-directive",
+        "costUsd": 0.6271079599999999,
         "result": {
           "success": true,
           "duration": 565732,
@@ -3211,6 +3500,7 @@
       },
       {
         "evalPath": "agent-030-app-router-migration-hard",
+        "costUsd": 1.15148764,
         "result": {
           "success": true,
           "duration": 630454,
@@ -3220,6 +3510,7 @@
       },
       {
         "evalPath": "agent-031-proxy-middleware",
+        "costUsd": 0.13076424,
         "result": {
           "success": true,
           "duration": 191961,
@@ -3229,6 +3520,7 @@
       },
       {
         "evalPath": "agent-032-use-cache-directive",
+        "costUsd": 0.25705308,
         "result": {
           "success": true,
           "duration": 236457,
@@ -3238,6 +3530,7 @@
       },
       {
         "evalPath": "agent-033-forbidden-auth",
+        "costUsd": 0.48483568,
         "result": {
           "success": true,
           "duration": 263701,
@@ -3247,6 +3540,7 @@
       },
       {
         "evalPath": "agent-034-async-cookies",
+        "costUsd": 0.09390072000000001,
         "result": {
           "success": true,
           "duration": 174825,
@@ -3256,6 +3550,7 @@
       },
       {
         "evalPath": "agent-035-connection-dynamic",
+        "costUsd": 0.28542572000000005,
         "result": {
           "success": true,
           "duration": 189349,
@@ -3265,6 +3560,7 @@
       },
       {
         "evalPath": "agent-036-after-response",
+        "costUsd": 0.11148536,
         "result": {
           "success": true,
           "duration": 224846,
@@ -3274,6 +3570,7 @@
       },
       {
         "evalPath": "agent-037-updatetag-cache",
+        "costUsd": 0.5869176799999999,
         "result": {
           "success": true,
           "duration": 348589,
@@ -3283,6 +3580,7 @@
       },
       {
         "evalPath": "agent-038-refresh-settings",
+        "costUsd": 0.18015212,
         "result": {
           "success": true,
           "duration": 219561,
@@ -3292,6 +3590,7 @@
       },
       {
         "evalPath": "agent-039-indirect-proxy",
+        "costUsd": 0.17122956,
         "result": {
           "success": true,
           "duration": 201942,
@@ -3311,6 +3610,7 @@
       },
       {
         "evalPath": "agent-041-optimize-ppr-shell",
+        "costUsd": 0.43348036,
         "result": {
           "success": true,
           "duration": 337323,
@@ -3320,6 +3620,7 @@
       },
       {
         "evalPath": "agent-042-enable-ppr",
+        "costUsd": 0.24273035999999998,
         "result": {
           "success": true,
           "duration": 188269,
@@ -3329,6 +3630,7 @@
       },
       {
         "evalPath": "agent-043-view-transitions",
+        "costUsd": 0.4090597999999999,
         "result": {
           "success": true,
           "duration": 412727,
@@ -3340,6 +3642,7 @@
     "gpt-5.2-codex-xhigh": [
       {
         "evalPath": "agent-000-app-router-migration-simple",
+        "costUsd": 0.2340079,
         "result": {
           "success": true,
           "duration": 236838,
@@ -3349,6 +3652,7 @@
       },
       {
         "evalPath": "agent-021-avoid-fetch-in-effect",
+        "costUsd": 0.08613885,
         "result": {
           "success": true,
           "duration": 153636,
@@ -3358,6 +3662,7 @@
       },
       {
         "evalPath": "agent-022-prefer-server-actions",
+        "costUsd": 0.11496345,
         "result": {
           "success": true,
           "duration": 122849,
@@ -3367,6 +3672,7 @@
       },
       {
         "evalPath": "agent-023-avoid-getserversideprops",
+        "costUsd": 0.1008462,
         "result": {
           "success": true,
           "duration": 135512,
@@ -3376,6 +3682,7 @@
       },
       {
         "evalPath": "agent-024-avoid-redundant-usestate",
+        "costUsd": 0.06194825,
         "result": {
           "success": true,
           "duration": 138336,
@@ -3385,6 +3692,7 @@
       },
       {
         "evalPath": "agent-025-prefer-next-link",
+        "costUsd": 0.048331149999999996,
         "result": {
           "success": true,
           "duration": 147974,
@@ -3394,6 +3702,7 @@
       },
       {
         "evalPath": "agent-026-no-serial-await",
+        "costUsd": 0.1552999,
         "result": {
           "success": true,
           "duration": 191078,
@@ -3403,6 +3712,7 @@
       },
       {
         "evalPath": "agent-027-prefer-next-image",
+        "costUsd": 0.0600369,
         "result": {
           "success": true,
           "duration": 141777,
@@ -3412,6 +3722,7 @@
       },
       {
         "evalPath": "agent-028-prefer-next-font",
+        "costUsd": 0.08063545,
         "result": {
           "success": true,
           "duration": 161483,
@@ -3421,6 +3732,7 @@
       },
       {
         "evalPath": "agent-029-use-cache-directive",
+        "costUsd": 0.45935644999999997,
         "result": {
           "success": false,
           "duration": 196658.75,
@@ -3430,6 +3742,7 @@
       },
       {
         "evalPath": "agent-030-app-router-migration-hard",
+        "costUsd": 0.952231,
         "result": {
           "success": false,
           "duration": 391628.75,
@@ -3439,6 +3752,7 @@
       },
       {
         "evalPath": "agent-031-proxy-middleware",
+        "costUsd": 0.08199625,
         "result": {
           "success": true,
           "duration": 154917,
@@ -3448,6 +3762,7 @@
       },
       {
         "evalPath": "agent-032-use-cache-directive",
+        "costUsd": 0.16410345,
         "result": {
           "success": true,
           "duration": 189840,
@@ -3457,6 +3772,7 @@
       },
       {
         "evalPath": "agent-033-forbidden-auth",
+        "costUsd": 0.15625785,
         "result": {
           "success": true,
           "duration": 105370,
@@ -3466,6 +3782,7 @@
       },
       {
         "evalPath": "agent-034-async-cookies",
+        "costUsd": 0.153678,
         "result": {
           "success": true,
           "duration": 155028,
@@ -3475,6 +3792,7 @@
       },
       {
         "evalPath": "agent-035-connection-dynamic",
+        "costUsd": 0.13304164999999998,
         "result": {
           "success": true,
           "duration": 88194.5,
@@ -3484,6 +3802,7 @@
       },
       {
         "evalPath": "agent-036-after-response",
+        "costUsd": 0.0886039,
         "result": {
           "success": true,
           "duration": 172718,
@@ -3493,6 +3812,7 @@
       },
       {
         "evalPath": "agent-037-updatetag-cache",
+        "costUsd": 0.2371187,
         "result": {
           "success": false,
           "duration": 123689,
@@ -3502,6 +3822,7 @@
       },
       {
         "evalPath": "agent-038-refresh-settings",
+        "costUsd": 0.147337575,
         "result": {
           "success": true,
           "duration": 86352.75000000001,
@@ -3511,6 +3832,7 @@
       },
       {
         "evalPath": "agent-039-indirect-proxy",
+        "costUsd": 0.062001099999999996,
         "result": {
           "success": true,
           "duration": 142635,
@@ -3530,6 +3852,7 @@
       },
       {
         "evalPath": "agent-041-optimize-ppr-shell",
+        "costUsd": 0.5838769125,
         "result": {
           "success": false,
           "duration": 270297.5,
@@ -3539,6 +3862,7 @@
       },
       {
         "evalPath": "agent-042-enable-ppr",
+        "costUsd": 0.0768201,
         "result": {
           "success": true,
           "duration": 94923,
@@ -3548,6 +3872,7 @@
       },
       {
         "evalPath": "agent-043-view-transitions",
+        "costUsd": 0.21713895000000002,
         "result": {
           "success": true,
           "duration": 186013,
@@ -3559,6 +3884,7 @@
     "gpt-5.3-codex-xhigh": [
       {
         "evalPath": "agent-000-app-router-migration-simple",
+        "costUsd": 0.4392255,
         "result": {
           "success": true,
           "duration": 301213,
@@ -3568,6 +3894,7 @@
       },
       {
         "evalPath": "agent-021-avoid-fetch-in-effect",
+        "costUsd": 0.1511699,
         "result": {
           "success": true,
           "duration": 204918,
@@ -3577,6 +3904,7 @@
       },
       {
         "evalPath": "agent-022-prefer-server-actions",
+        "costUsd": 0.20979945,
         "result": {
           "success": true,
           "duration": 179465,
@@ -3586,6 +3914,7 @@
       },
       {
         "evalPath": "agent-023-avoid-getserversideprops",
+        "costUsd": 0.23616004999999998,
         "result": {
           "success": true,
           "duration": 185761.5,
@@ -3595,6 +3924,7 @@
       },
       {
         "evalPath": "agent-024-avoid-redundant-usestate",
+        "costUsd": 0.09450175,
         "result": {
           "success": true,
           "duration": 77422.66666666667,
@@ -3604,6 +3934,7 @@
       },
       {
         "evalPath": "agent-025-prefer-next-link",
+        "costUsd": 0.1105363,
         "result": {
           "success": true,
           "duration": 178804,
@@ -3613,6 +3944,7 @@
       },
       {
         "evalPath": "agent-026-no-serial-await",
+        "costUsd": 0.25507615,
         "result": {
           "success": true,
           "duration": 254145,
@@ -3622,6 +3954,7 @@
       },
       {
         "evalPath": "agent-027-prefer-next-image",
+        "costUsd": 0.14605815,
         "result": {
           "success": true,
           "duration": 222453,
@@ -3631,6 +3964,7 @@
       },
       {
         "evalPath": "agent-028-prefer-next-font",
+        "costUsd": 0.1588076,
         "result": {
           "success": true,
           "duration": 179537,
@@ -3640,6 +3974,7 @@
       },
       {
         "evalPath": "agent-029-use-cache-directive",
+        "costUsd": 0.60549965,
         "result": {
           "success": true,
           "duration": 339497.5,
@@ -3649,6 +3984,7 @@
       },
       {
         "evalPath": "agent-030-app-router-migration-hard",
+        "costUsd": 0.74080615,
         "result": {
           "success": true,
           "duration": 440175.25,
@@ -3658,6 +3994,7 @@
       },
       {
         "evalPath": "agent-031-proxy-middleware",
+        "costUsd": 0.1435287,
         "result": {
           "success": true,
           "duration": 181744,
@@ -3667,6 +4004,7 @@
       },
       {
         "evalPath": "agent-032-use-cache-directive",
+        "costUsd": 0.31565309999999996,
         "result": {
           "success": true,
           "duration": 283251,
@@ -3676,6 +4014,7 @@
       },
       {
         "evalPath": "agent-033-forbidden-auth",
+        "costUsd": 0.23724575,
         "result": {
           "success": true,
           "duration": 133320.5,
@@ -3685,6 +4024,7 @@
       },
       {
         "evalPath": "agent-034-async-cookies",
+        "costUsd": 0.20007959999999997,
         "result": {
           "success": true,
           "duration": 85420,
@@ -3694,6 +4034,7 @@
       },
       {
         "evalPath": "agent-035-connection-dynamic",
+        "costUsd": 0.25592245,
         "result": {
           "success": true,
           "duration": 79968.5,
@@ -3703,6 +4044,7 @@
       },
       {
         "evalPath": "agent-036-after-response",
+        "costUsd": 0.17582985,
         "result": {
           "success": true,
           "duration": 212046,
@@ -3712,6 +4054,7 @@
       },
       {
         "evalPath": "agent-037-updatetag-cache",
+        "costUsd": 0.34166405,
         "result": {
           "success": true,
           "duration": 288604,
@@ -3721,6 +4064,7 @@
       },
       {
         "evalPath": "agent-038-refresh-settings",
+        "costUsd": 0.19283039999999999,
         "result": {
           "success": true,
           "duration": 225890,
@@ -3730,6 +4074,7 @@
       },
       {
         "evalPath": "agent-039-indirect-proxy",
+        "costUsd": 0.13249460000000002,
         "result": {
           "success": true,
           "duration": 103143.5,
@@ -3749,6 +4094,7 @@
       },
       {
         "evalPath": "agent-041-optimize-ppr-shell",
+        "costUsd": 0.5654018125,
         "result": {
           "success": false,
           "duration": 267621.25,
@@ -3758,6 +4104,7 @@
       },
       {
         "evalPath": "agent-042-enable-ppr",
+        "costUsd": 0.11081035,
         "result": {
           "success": true,
           "duration": 130312.00000000001,
@@ -3767,6 +4114,7 @@
       },
       {
         "evalPath": "agent-043-view-transitions",
+        "costUsd": 0.34896365,
         "result": {
           "success": true,
           "duration": 227976,
@@ -3778,6 +4126,7 @@
     "gpt-5.4-xhigh": [
       {
         "evalPath": "agent-000-app-router-migration-simple",
+        "costUsd": 0.260343,
         "result": {
           "success": true,
           "duration": 225286,
@@ -3787,6 +4136,7 @@
       },
       {
         "evalPath": "agent-021-avoid-fetch-in-effect",
+        "costUsd": 0.1675595,
         "result": {
           "success": true,
           "duration": 161711,
@@ -3796,6 +4146,7 @@
       },
       {
         "evalPath": "agent-022-prefer-server-actions",
+        "costUsd": 0.149606,
         "result": {
           "success": true,
           "duration": 169967,
@@ -3805,6 +4156,7 @@
       },
       {
         "evalPath": "agent-023-avoid-getserversideprops",
+        "costUsd": 0.292033,
         "result": {
           "success": true,
           "duration": 171181,
@@ -3814,6 +4166,7 @@
       },
       {
         "evalPath": "agent-024-avoid-redundant-usestate",
+        "costUsd": 0.107907,
         "result": {
           "success": true,
           "duration": 150318,
@@ -3823,6 +4176,7 @@
       },
       {
         "evalPath": "agent-025-prefer-next-link",
+        "costUsd": 0.099378,
         "result": {
           "success": true,
           "duration": 125116,
@@ -3832,6 +4186,7 @@
       },
       {
         "evalPath": "agent-026-no-serial-await",
+        "costUsd": 0.4837705,
         "result": {
           "success": true,
           "duration": 291895,
@@ -3841,6 +4196,7 @@
       },
       {
         "evalPath": "agent-027-prefer-next-image",
+        "costUsd": 0.1850095,
         "result": {
           "success": true,
           "duration": 166251,
@@ -3850,6 +4206,7 @@
       },
       {
         "evalPath": "agent-028-prefer-next-font",
+        "costUsd": 0.135988,
         "result": {
           "success": true,
           "duration": 127397,
@@ -3859,6 +4216,7 @@
       },
       {
         "evalPath": "agent-029-use-cache-directive",
+        "costUsd": 0.577323,
         "result": {
           "success": true,
           "duration": 424849,
@@ -3870,13 +4228,14 @@
         "evalPath": "agent-030-app-router-migration-hard",
         "result": {
           "success": false,
-          "duration": 372254.5,
+          "duration": 720005.2499999999,
           "evalPath": "agent-030-app-router-migration-hard",
-          "timestamp": "2026-03-21T19:40:53.388Z"
+          "timestamp": "2026-07-17T19:18:24.998Z"
         }
       },
       {
         "evalPath": "agent-031-proxy-middleware",
+        "costUsd": 0.206392,
         "result": {
           "success": true,
           "duration": 160788,
@@ -3886,6 +4245,7 @@
       },
       {
         "evalPath": "agent-032-use-cache-directive",
+        "costUsd": 0.2667575,
         "result": {
           "success": true,
           "duration": 196322,
@@ -3895,6 +4255,7 @@
       },
       {
         "evalPath": "agent-033-forbidden-auth",
+        "costUsd": 0.3535745,
         "result": {
           "success": true,
           "duration": 261480.00000000003,
@@ -3904,6 +4265,7 @@
       },
       {
         "evalPath": "agent-034-async-cookies",
+        "costUsd": 0.210182,
         "result": {
           "success": true,
           "duration": 186072.99999999997,
@@ -3913,6 +4275,7 @@
       },
       {
         "evalPath": "agent-035-connection-dynamic",
+        "costUsd": 0.199465,
         "result": {
           "success": true,
           "duration": 165453,
@@ -3922,6 +4285,7 @@
       },
       {
         "evalPath": "agent-036-after-response",
+        "costUsd": 0.3176135,
         "result": {
           "success": true,
           "duration": 237730,
@@ -3931,6 +4295,7 @@
       },
       {
         "evalPath": "agent-037-updatetag-cache",
+        "costUsd": 0.333545,
         "result": {
           "success": true,
           "duration": 225880,
@@ -3940,6 +4305,7 @@
       },
       {
         "evalPath": "agent-038-refresh-settings",
+        "costUsd": 0.207701,
         "result": {
           "success": true,
           "duration": 166883,
@@ -3949,6 +4315,7 @@
       },
       {
         "evalPath": "agent-039-indirect-proxy",
+        "costUsd": 0.166265,
         "result": {
           "success": true,
           "duration": 159541,
@@ -3963,11 +4330,12 @@
           "success": false,
           "duration": 0,
           "evalPath": "agent-040-instant",
-          "timestamp": "2026-04-06T14:41:53.421Z"
+          "timestamp": "2026-07-17T19:18:24.998Z"
         }
       },
       {
         "evalPath": "agent-041-optimize-ppr-shell",
+        "costUsd": 0.609241,
         "result": {
           "success": false,
           "duration": 385572,
@@ -3977,6 +4345,7 @@
       },
       {
         "evalPath": "agent-042-enable-ppr",
+        "costUsd": 0.267734,
         "result": {
           "success": true,
           "duration": 196091,
@@ -3986,6 +4355,7 @@
       },
       {
         "evalPath": "agent-043-view-transitions",
+        "costUsd": 0.5325985,
         "result": {
           "success": true,
           "duration": 330734,
@@ -3997,6 +4367,7 @@
     "gpt-5.5-pro": [
       {
         "evalPath": "agent-000-app-router-migration-simple",
+        "costUsd": 24.57582,
         "result": {
           "success": true,
           "duration": 1075633,
@@ -4006,6 +4377,7 @@
       },
       {
         "evalPath": "agent-021-avoid-fetch-in-effect",
+        "costUsd": 15.74124,
         "result": {
           "success": true,
           "duration": 694195,
@@ -4015,6 +4387,7 @@
       },
       {
         "evalPath": "agent-022-prefer-server-actions",
+        "costUsd": 6.99561,
         "result": {
           "success": true,
           "duration": 445752,
@@ -4024,6 +4397,7 @@
       },
       {
         "evalPath": "agent-023-avoid-getserversideprops",
+        "costUsd": 15.76047,
         "result": {
           "success": true,
           "duration": 532130,
@@ -4033,6 +4407,7 @@
       },
       {
         "evalPath": "agent-024-avoid-redundant-usestate",
+        "costUsd": 8.71575,
         "result": {
           "success": true,
           "duration": 666153,
@@ -4042,6 +4417,7 @@
       },
       {
         "evalPath": "agent-025-prefer-next-link",
+        "costUsd": 8.72931,
         "result": {
           "success": true,
           "duration": 518144,
@@ -4051,6 +4427,7 @@
       },
       {
         "evalPath": "agent-026-no-serial-await",
+        "costUsd": 11.69208,
         "result": {
           "success": true,
           "duration": 725309,
@@ -4060,6 +4437,7 @@
       },
       {
         "evalPath": "agent-027-prefer-next-image",
+        "costUsd": 20.6241,
         "result": {
           "success": true,
           "duration": 1037050.9999999999,
@@ -4069,6 +4447,7 @@
       },
       {
         "evalPath": "agent-028-prefer-next-font",
+        "costUsd": 20.58579,
         "result": {
           "success": true,
           "duration": 805923,
@@ -4078,6 +4457,7 @@
       },
       {
         "evalPath": "agent-029-use-cache-directive",
+        "costUsd": 32.61042,
         "result": {
           "success": false,
           "duration": 1250960,
@@ -4087,6 +4467,7 @@
       },
       {
         "evalPath": "agent-030-app-router-migration-hard",
+        "costUsd": 58.51227,
         "result": {
           "success": false,
           "duration": 1714000,
@@ -4096,6 +4477,7 @@
       },
       {
         "evalPath": "agent-031-proxy-middleware",
+        "costUsd": 16.19244,
         "result": {
           "success": true,
           "duration": 826892,
@@ -4105,6 +4487,7 @@
       },
       {
         "evalPath": "agent-032-use-cache-directive",
+        "costUsd": 16.54059,
         "result": {
           "success": true,
           "duration": 982041,
@@ -4114,6 +4497,7 @@
       },
       {
         "evalPath": "agent-033-forbidden-auth",
+        "costUsd": 19.81995,
         "result": {
           "success": true,
           "duration": 907532,
@@ -4123,6 +4507,7 @@
       },
       {
         "evalPath": "agent-034-async-cookies",
+        "costUsd": 18.19662,
         "result": {
           "success": true,
           "duration": 650750,
@@ -4132,6 +4517,7 @@
       },
       {
         "evalPath": "agent-035-connection-dynamic",
+        "costUsd": 20.4015,
         "result": {
           "success": true,
           "duration": 765425,
@@ -4141,6 +4527,7 @@
       },
       {
         "evalPath": "agent-036-after-response",
+        "costUsd": 25.99479,
         "result": {
           "success": true,
           "duration": 1352811,
@@ -4150,6 +4537,7 @@
       },
       {
         "evalPath": "agent-037-updatetag-cache",
+        "costUsd": 24.02787,
         "result": {
           "success": true,
           "duration": 771434,
@@ -4159,6 +4547,7 @@
       },
       {
         "evalPath": "agent-038-refresh-settings",
+        "costUsd": 40.8798,
         "result": {
           "success": true,
           "duration": 1195528,
@@ -4168,6 +4557,7 @@
       },
       {
         "evalPath": "agent-039-indirect-proxy",
+        "costUsd": 14.87388,
         "result": {
           "success": true,
           "duration": 848016,
@@ -4187,6 +4577,7 @@
       },
       {
         "evalPath": "agent-041-optimize-ppr-shell",
+        "costUsd": 81.89172,
         "result": {
           "success": false,
           "duration": 1359297,
@@ -4196,6 +4587,7 @@
       },
       {
         "evalPath": "agent-042-enable-ppr",
+        "costUsd": 13.75029,
         "result": {
           "success": true,
           "duration": 545281,
@@ -4205,6 +4597,7 @@
       },
       {
         "evalPath": "agent-043-view-transitions",
+        "costUsd": 48.22239,
         "result": {
           "success": true,
           "duration": 1029907.9999999999,
@@ -4216,6 +4609,7 @@
     "gpt-5.6-sol-ultra": [
       {
         "evalPath": "agent-000-app-router-migration-simple",
+        "costUsd": 1.162263,
         "result": {
           "success": true,
           "duration": 252719,
@@ -4225,6 +4619,7 @@
       },
       {
         "evalPath": "agent-021-avoid-fetch-in-effect",
+        "costUsd": 0.646162,
         "result": {
           "success": true,
           "duration": 205946,
@@ -4234,6 +4629,7 @@
       },
       {
         "evalPath": "agent-022-prefer-server-actions",
+        "costUsd": 0.4635775,
         "result": {
           "success": true,
           "duration": 180013,
@@ -4243,6 +4639,7 @@
       },
       {
         "evalPath": "agent-023-avoid-getserversideprops",
+        "costUsd": 0.446005,
         "result": {
           "success": true,
           "duration": 174790,
@@ -4252,6 +4649,7 @@
       },
       {
         "evalPath": "agent-024-avoid-redundant-usestate",
+        "costUsd": 0.4318675,
         "result": {
           "success": true,
           "duration": 182050,
@@ -4261,6 +4659,7 @@
       },
       {
         "evalPath": "agent-025-prefer-next-link",
+        "costUsd": 0.4417235,
         "result": {
           "success": true,
           "duration": 156181,
@@ -4270,6 +4669,7 @@
       },
       {
         "evalPath": "agent-026-no-serial-await",
+        "costUsd": 0.701808,
         "result": {
           "success": true,
           "duration": 244357,
@@ -4279,6 +4679,7 @@
       },
       {
         "evalPath": "agent-027-prefer-next-image",
+        "costUsd": 0.439312,
         "result": {
           "success": true,
           "duration": 150394,
@@ -4288,6 +4689,7 @@
       },
       {
         "evalPath": "agent-028-prefer-next-font",
+        "costUsd": 0.379676,
         "result": {
           "success": true,
           "duration": 156840,
@@ -4297,6 +4699,7 @@
       },
       {
         "evalPath": "agent-029-use-cache-directive",
+        "costUsd": 0.958436,
         "result": {
           "success": true,
           "duration": 255544,
@@ -4306,6 +4709,7 @@
       },
       {
         "evalPath": "agent-030-app-router-migration-hard",
+        "costUsd": 5.3223025,
         "result": {
           "success": true,
           "duration": 851668,
@@ -4315,6 +4719,7 @@
       },
       {
         "evalPath": "agent-031-proxy-middleware",
+        "costUsd": 0.4437325,
         "result": {
           "success": true,
           "duration": 164040,
@@ -4324,6 +4729,7 @@
       },
       {
         "evalPath": "agent-032-use-cache-directive",
+        "costUsd": 0.6902765,
         "result": {
           "success": true,
           "duration": 199347,
@@ -4333,6 +4739,7 @@
       },
       {
         "evalPath": "agent-033-forbidden-auth",
+        "costUsd": 0.8902815,
         "result": {
           "success": true,
           "duration": 254530,
@@ -4342,6 +4749,7 @@
       },
       {
         "evalPath": "agent-034-async-cookies",
+        "costUsd": 0.6214845,
         "result": {
           "success": true,
           "duration": 264503,
@@ -4351,6 +4759,7 @@
       },
       {
         "evalPath": "agent-035-connection-dynamic",
+        "costUsd": 0.5281085,
         "result": {
           "success": true,
           "duration": 168421,
@@ -4360,6 +4769,7 @@
       },
       {
         "evalPath": "agent-036-after-response",
+        "costUsd": 0.76082,
         "result": {
           "success": true,
           "duration": 248641,
@@ -4369,6 +4779,7 @@
       },
       {
         "evalPath": "agent-037-updatetag-cache",
+        "costUsd": 1.1327275,
         "result": {
           "success": true,
           "duration": 332325,
@@ -4378,6 +4789,7 @@
       },
       {
         "evalPath": "agent-038-refresh-settings",
+        "costUsd": 0.9326435,
         "result": {
           "success": true,
           "duration": 230926,
@@ -4387,6 +4799,7 @@
       },
       {
         "evalPath": "agent-039-indirect-proxy",
+        "costUsd": 0.51572,
         "result": {
           "success": true,
           "duration": 172503,
@@ -4396,6 +4809,7 @@
       },
       {
         "evalPath": "agent-040-instant",
+        "costUsd": 1.0755979999999998,
         "result": {
           "success": false,
           "duration": 266121.25,
@@ -4405,6 +4819,7 @@
       },
       {
         "evalPath": "agent-041-optimize-ppr-shell",
+        "costUsd": 1.38180275,
         "result": {
           "success": false,
           "duration": 474256.25,
@@ -4414,6 +4829,7 @@
       },
       {
         "evalPath": "agent-042-enable-ppr",
+        "costUsd": 0.5119815,
         "result": {
           "success": true,
           "duration": 163206,
@@ -4423,6 +4839,7 @@
       },
       {
         "evalPath": "agent-043-view-transitions",
+        "costUsd": 1.3523205,
         "result": {
           "success": true,
           "duration": 400794,
@@ -4434,6 +4851,7 @@
     "grok-4.5": [
       {
         "evalPath": "agent-000-app-router-migration-simple",
+        "costUsd": 0.114356,
         "result": {
           "success": true,
           "duration": 151021.25,
@@ -4443,6 +4861,7 @@
       },
       {
         "evalPath": "agent-021-avoid-fetch-in-effect",
+        "costUsd": 0.050132,
         "result": {
           "success": true,
           "duration": 144475,
@@ -4452,6 +4871,7 @@
       },
       {
         "evalPath": "agent-022-prefer-server-actions",
+        "costUsd": 0.075772,
         "result": {
           "success": true,
           "duration": 203688,
@@ -4461,6 +4881,7 @@
       },
       {
         "evalPath": "agent-023-avoid-getserversideprops",
+        "costUsd": 0.152184,
         "result": {
           "success": true,
           "duration": 130937.99999999999,
@@ -4470,6 +4891,7 @@
       },
       {
         "evalPath": "agent-024-avoid-redundant-usestate",
+        "costUsd": 0.043178,
         "result": {
           "success": true,
           "duration": 162554,
@@ -4479,6 +4901,7 @@
       },
       {
         "evalPath": "agent-025-prefer-next-link",
+        "costUsd": 0.060726,
         "result": {
           "success": true,
           "duration": 117721,
@@ -4488,6 +4911,7 @@
       },
       {
         "evalPath": "agent-026-no-serial-await",
+        "costUsd": 0.09385,
         "result": {
           "success": true,
           "duration": 122710,
@@ -4497,6 +4921,7 @@
       },
       {
         "evalPath": "agent-027-prefer-next-image",
+        "costUsd": 0.0491,
         "result": {
           "success": true,
           "duration": 117649,
@@ -4506,6 +4931,7 @@
       },
       {
         "evalPath": "agent-028-prefer-next-font",
+        "costUsd": 0.092778,
         "result": {
           "success": true,
           "duration": 120619,
@@ -4515,6 +4941,7 @@
       },
       {
         "evalPath": "agent-029-use-cache-directive",
+        "costUsd": 0.223886,
         "result": {
           "success": true,
           "duration": 141594.49999999997,
@@ -4524,6 +4951,7 @@
       },
       {
         "evalPath": "agent-030-app-router-migration-hard",
+        "costUsd": 0.290934,
         "result": {
           "success": true,
           "duration": 271551,
@@ -4533,6 +4961,7 @@
       },
       {
         "evalPath": "agent-031-proxy-middleware",
+        "costUsd": 0.13014,
         "result": {
           "success": true,
           "duration": 120730,
@@ -4542,6 +4971,7 @@
       },
       {
         "evalPath": "agent-032-use-cache-directive",
+        "costUsd": 0.142538,
         "result": {
           "success": true,
           "duration": 135641,
@@ -4551,6 +4981,7 @@
       },
       {
         "evalPath": "agent-033-forbidden-auth",
+        "costUsd": 0.120212,
         "result": {
           "success": true,
           "duration": 130305,
@@ -4560,6 +4991,7 @@
       },
       {
         "evalPath": "agent-034-async-cookies",
+        "costUsd": 0.083116,
         "result": {
           "success": true,
           "duration": 247378,
@@ -4569,6 +5001,7 @@
       },
       {
         "evalPath": "agent-035-connection-dynamic",
+        "costUsd": 0.078468,
         "result": {
           "success": true,
           "duration": 108328,
@@ -4578,6 +5011,7 @@
       },
       {
         "evalPath": "agent-036-after-response",
+        "costUsd": 0.108882,
         "result": {
           "success": true,
           "duration": 105176,
@@ -4587,6 +5021,7 @@
       },
       {
         "evalPath": "agent-037-updatetag-cache",
+        "costUsd": 0.07492,
         "result": {
           "success": true,
           "duration": 223980,
@@ -4596,6 +5031,7 @@
       },
       {
         "evalPath": "agent-038-refresh-settings",
+        "costUsd": 0.1238,
         "result": {
           "success": true,
           "duration": 109265,
@@ -4605,6 +5041,7 @@
       },
       {
         "evalPath": "agent-039-indirect-proxy",
+        "costUsd": 0.07594,
         "result": {
           "success": true,
           "duration": 109964,
@@ -4614,6 +5051,7 @@
       },
       {
         "evalPath": "agent-040-instant",
+        "costUsd": 0.1171045,
         "result": {
           "success": false,
           "duration": 141459.25,
@@ -4623,6 +5061,7 @@
       },
       {
         "evalPath": "agent-041-optimize-ppr-shell",
+        "costUsd": 0.240982,
         "result": {
           "success": true,
           "duration": 143492,
@@ -4632,6 +5071,7 @@
       },
       {
         "evalPath": "agent-042-enable-ppr",
+        "costUsd": 0.054948,
         "result": {
           "success": true,
           "duration": 110151,
@@ -4641,6 +5081,7 @@
       },
       {
         "evalPath": "agent-043-view-transitions",
+        "costUsd": 0.190736,
         "result": {
           "success": true,
           "duration": 174543,
@@ -4652,6 +5093,7 @@
     "kimi-k2.5": [
       {
         "evalPath": "agent-000-app-router-migration-simple",
+        "costUsd": 0.0202834,
         "result": {
           "success": true,
           "duration": 151748,
@@ -4661,6 +5103,7 @@
       },
       {
         "evalPath": "agent-021-avoid-fetch-in-effect",
+        "costUsd": 0.008283350000000002,
         "result": {
           "success": true,
           "duration": 127872,
@@ -4670,6 +5113,7 @@
       },
       {
         "evalPath": "agent-022-prefer-server-actions",
+        "costUsd": 0.013458149999999999,
         "result": {
           "success": true,
           "duration": 122007.74999999999,
@@ -4679,6 +5123,7 @@
       },
       {
         "evalPath": "agent-023-avoid-getserversideprops",
+        "costUsd": 0.013017299999999999,
         "result": {
           "success": true,
           "duration": 124493,
@@ -4688,6 +5133,7 @@
       },
       {
         "evalPath": "agent-024-avoid-redundant-usestate",
+        "costUsd": 0.0135718,
         "result": {
           "success": true,
           "duration": 126173,
@@ -4697,6 +5143,7 @@
       },
       {
         "evalPath": "agent-025-prefer-next-link",
+        "costUsd": 0.0116407,
         "result": {
           "success": true,
           "duration": 121133.5,
@@ -4706,6 +5153,7 @@
       },
       {
         "evalPath": "agent-026-no-serial-await",
+        "costUsd": 0.012986675,
         "result": {
           "success": true,
           "duration": 128167.25,
@@ -4715,6 +5163,7 @@
       },
       {
         "evalPath": "agent-027-prefer-next-image",
+        "costUsd": 0.0185152,
         "result": {
           "success": true,
           "duration": 131185,
@@ -4724,6 +5173,7 @@
       },
       {
         "evalPath": "agent-028-prefer-next-font",
+        "costUsd": 0.01168395,
         "result": {
           "success": false,
           "duration": 120400.25,
@@ -4733,6 +5183,7 @@
       },
       {
         "evalPath": "agent-029-use-cache-directive",
+        "costUsd": 0.01148105,
         "result": {
           "success": false,
           "duration": 118707.74999999999,
@@ -4742,6 +5193,7 @@
       },
       {
         "evalPath": "agent-030-app-router-migration-hard",
+        "costUsd": 0.02049085,
         "result": {
           "success": false,
           "duration": 149373.24999999997,
@@ -4751,6 +5203,7 @@
       },
       {
         "evalPath": "agent-031-proxy-middleware",
+        "costUsd": 0.028482300000000002,
         "result": {
           "success": true,
           "duration": 125260,
@@ -4760,6 +5213,7 @@
       },
       {
         "evalPath": "agent-032-use-cache-directive",
+        "costUsd": 0.017961375,
         "result": {
           "success": false,
           "duration": 112956.5,
@@ -4769,6 +5223,7 @@
       },
       {
         "evalPath": "agent-033-forbidden-auth",
+        "costUsd": 0.017238575,
         "result": {
           "success": false,
           "duration": 118572,
@@ -4778,6 +5233,7 @@
       },
       {
         "evalPath": "agent-034-async-cookies",
+        "costUsd": 0.013532675,
         "result": {
           "success": false,
           "duration": 114247.00000000001,
@@ -4787,6 +5243,7 @@
       },
       {
         "evalPath": "agent-035-connection-dynamic",
+        "costUsd": 0.011259624999999999,
         "result": {
           "success": false,
           "duration": 112333.99999999999,
@@ -4796,6 +5253,7 @@
       },
       {
         "evalPath": "agent-036-after-response",
+        "costUsd": 0.0121213,
         "result": {
           "success": false,
           "duration": 110540.25,
@@ -4805,6 +5263,7 @@
       },
       {
         "evalPath": "agent-037-updatetag-cache",
+        "costUsd": 0.0281995,
         "result": {
           "success": true,
           "duration": 153363,
@@ -4814,6 +5273,7 @@
       },
       {
         "evalPath": "agent-038-refresh-settings",
+        "costUsd": 0.0115599,
         "result": {
           "success": false,
           "duration": 110278,
@@ -4823,6 +5283,7 @@
       },
       {
         "evalPath": "agent-039-indirect-proxy",
+        "costUsd": 0.019013199999999997,
         "result": {
           "success": true,
           "duration": 118381,
@@ -4842,6 +5303,7 @@
       },
       {
         "evalPath": "agent-041-optimize-ppr-shell",
+        "costUsd": 0.07030064999999999,
         "result": {
           "success": true,
           "duration": 206277,
@@ -4851,6 +5313,7 @@
       },
       {
         "evalPath": "agent-042-enable-ppr",
+        "costUsd": 0.0342467,
         "result": {
           "success": true,
           "duration": 134774,
@@ -4860,6 +5323,7 @@
       },
       {
         "evalPath": "agent-043-view-transitions",
+        "costUsd": 0.0556685,
         "result": {
           "success": true,
           "duration": 293134,
@@ -4871,6 +5335,7 @@
     "kimi-k2.6": [
       {
         "evalPath": "agent-000-app-router-migration-simple",
+        "costUsd": 0.044802760000000004,
         "result": {
           "success": true,
           "duration": 243621,
@@ -4880,6 +5345,7 @@
       },
       {
         "evalPath": "agent-021-avoid-fetch-in-effect",
+        "costUsd": 0.07843417999999999,
         "result": {
           "success": true,
           "duration": 212991,
@@ -4889,6 +5355,7 @@
       },
       {
         "evalPath": "agent-022-prefer-server-actions",
+        "costUsd": 0.042963259999999996,
         "result": {
           "success": true,
           "duration": 180330,
@@ -4898,6 +5365,7 @@
       },
       {
         "evalPath": "agent-023-avoid-getserversideprops",
+        "costUsd": 0.02455539,
         "result": {
           "success": true,
           "duration": 173303,
@@ -4907,6 +5375,7 @@
       },
       {
         "evalPath": "agent-024-avoid-redundant-usestate",
+        "costUsd": 0.01247524,
         "result": {
           "success": true,
           "duration": 149727,
@@ -4916,6 +5385,7 @@
       },
       {
         "evalPath": "agent-025-prefer-next-link",
+        "costUsd": 0.011754299999999999,
         "result": {
           "success": true,
           "duration": 153605,
@@ -4925,6 +5395,7 @@
       },
       {
         "evalPath": "agent-026-no-serial-await",
+        "costUsd": 0.012481959999999999,
         "result": {
           "success": true,
           "duration": 181079,
@@ -4934,6 +5405,7 @@
       },
       {
         "evalPath": "agent-027-prefer-next-image",
+        "costUsd": 0.01725672,
         "result": {
           "success": true,
           "duration": 148334,
@@ -4943,6 +5415,7 @@
       },
       {
         "evalPath": "agent-028-prefer-next-font",
+        "costUsd": 0.034717815,
         "result": {
           "success": true,
           "duration": 153779.49999999997,
@@ -4952,6 +5425,7 @@
       },
       {
         "evalPath": "agent-029-use-cache-directive",
+        "costUsd": 0.15341819999999998,
         "result": {
           "success": true,
           "duration": 334100.25,
@@ -4961,6 +5435,7 @@
       },
       {
         "evalPath": "agent-030-app-router-migration-hard",
+        "costUsd": 0.30242296999999996,
         "result": {
           "success": true,
           "duration": 438425,
@@ -4970,6 +5445,7 @@
       },
       {
         "evalPath": "agent-031-proxy-middleware",
+        "costUsd": 0.02910184,
         "result": {
           "success": true,
           "duration": 158476,
@@ -4979,6 +5455,7 @@
       },
       {
         "evalPath": "agent-032-use-cache-directive",
+        "costUsd": 0.07849313499999999,
         "result": {
           "success": true,
           "duration": 219055,
@@ -4988,6 +5465,7 @@
       },
       {
         "evalPath": "agent-033-forbidden-auth",
+        "costUsd": 0.04851625,
         "result": {
           "success": true,
           "duration": 234717,
@@ -4997,6 +5475,7 @@
       },
       {
         "evalPath": "agent-034-async-cookies",
+        "costUsd": 0.03087839,
         "result": {
           "success": true,
           "duration": 154767,
@@ -5006,6 +5485,7 @@
       },
       {
         "evalPath": "agent-035-connection-dynamic",
+        "costUsd": 0.09015484,
         "result": {
           "success": true,
           "duration": 162725,
@@ -5015,6 +5495,7 @@
       },
       {
         "evalPath": "agent-036-after-response",
+        "costUsd": 0.04723378999999999,
         "result": {
           "success": true,
           "duration": 162063,
@@ -5024,6 +5505,7 @@
       },
       {
         "evalPath": "agent-037-updatetag-cache",
+        "costUsd": 0.05762236,
         "result": {
           "success": true,
           "duration": 225288,
@@ -5033,6 +5515,7 @@
       },
       {
         "evalPath": "agent-038-refresh-settings",
+        "costUsd": 0.05765024,
         "result": {
           "success": true,
           "duration": 182855,
@@ -5042,6 +5525,7 @@
       },
       {
         "evalPath": "agent-039-indirect-proxy",
+        "costUsd": 0.037918675,
         "result": {
           "success": true,
           "duration": 148890.5,
@@ -5061,6 +5545,7 @@
       },
       {
         "evalPath": "agent-041-optimize-ppr-shell",
+        "costUsd": 0.17298635333333334,
         "result": {
           "success": true,
           "duration": 293253.3333333333,
@@ -5070,6 +5555,7 @@
       },
       {
         "evalPath": "agent-042-enable-ppr",
+        "costUsd": 0.052837949999999995,
         "result": {
           "success": true,
           "duration": 155196,
@@ -5079,6 +5565,7 @@
       },
       {
         "evalPath": "agent-043-view-transitions",
+        "costUsd": 0.16972742999999998,
         "result": {
           "success": true,
           "duration": 298531,
@@ -5090,6 +5577,7 @@
     "kimi-k2.7-code": [
       {
         "evalPath": "agent-000-app-router-migration-simple",
+        "costUsd": 0.04969047,
         "result": {
           "success": true,
           "duration": 218962,
@@ -5099,6 +5587,7 @@
       },
       {
         "evalPath": "agent-021-avoid-fetch-in-effect",
+        "costUsd": 0.01829298,
         "result": {
           "success": true,
           "duration": 185940,
@@ -5108,6 +5597,7 @@
       },
       {
         "evalPath": "agent-022-prefer-server-actions",
+        "costUsd": 0.02024295,
         "result": {
           "success": true,
           "duration": 182827,
@@ -5117,6 +5607,7 @@
       },
       {
         "evalPath": "agent-023-avoid-getserversideprops",
+        "costUsd": 0.050534575000000005,
         "result": {
           "success": true,
           "duration": 199246.5,
@@ -5126,6 +5617,7 @@
       },
       {
         "evalPath": "agent-024-avoid-redundant-usestate",
+        "costUsd": 0.015544369999999998,
         "result": {
           "success": true,
           "duration": 155875,
@@ -5135,6 +5627,7 @@
       },
       {
         "evalPath": "agent-025-prefer-next-link",
+        "costUsd": 0.012505990000000002,
         "result": {
           "success": true,
           "duration": 155426,
@@ -5144,6 +5637,7 @@
       },
       {
         "evalPath": "agent-026-no-serial-await",
+        "costUsd": 0.03225041,
         "result": {
           "success": true,
           "duration": 203553,
@@ -5153,6 +5647,7 @@
       },
       {
         "evalPath": "agent-027-prefer-next-image",
+        "costUsd": 0.02088168,
         "result": {
           "success": true,
           "duration": 178221,
@@ -5162,6 +5657,7 @@
       },
       {
         "evalPath": "agent-028-prefer-next-font",
+        "costUsd": 0.04350901,
         "result": {
           "success": true,
           "duration": 184318,
@@ -5171,6 +5667,7 @@
       },
       {
         "evalPath": "agent-029-use-cache-directive",
+        "costUsd": 0.17649747666666668,
         "result": {
           "success": true,
           "duration": 297070.3333333333,
@@ -5180,6 +5677,7 @@
       },
       {
         "evalPath": "agent-030-app-router-migration-hard",
+        "costUsd": 0.29602097,
         "result": {
           "success": true,
           "duration": 430699,
@@ -5189,6 +5687,7 @@
       },
       {
         "evalPath": "agent-031-proxy-middleware",
+        "costUsd": 0.044539039999999995,
         "result": {
           "success": true,
           "duration": 189761,
@@ -5198,6 +5697,7 @@
       },
       {
         "evalPath": "agent-032-use-cache-directive",
+        "costUsd": 0.07784231,
         "result": {
           "success": true,
           "duration": 186873,
@@ -5207,6 +5707,7 @@
       },
       {
         "evalPath": "agent-033-forbidden-auth",
+        "costUsd": 0.12037808,
         "result": {
           "success": true,
           "duration": 190992,
@@ -5216,6 +5717,7 @@
       },
       {
         "evalPath": "agent-034-async-cookies",
+        "costUsd": 0.056410560000000005,
         "result": {
           "success": true,
           "duration": 175574,
@@ -5225,6 +5727,7 @@
       },
       {
         "evalPath": "agent-035-connection-dynamic",
+        "costUsd": 0.03963783,
         "result": {
           "success": true,
           "duration": 174378,
@@ -5234,6 +5737,7 @@
       },
       {
         "evalPath": "agent-036-after-response",
+        "costUsd": 0.04786275,
         "result": {
           "success": true,
           "duration": 182505,
@@ -5243,6 +5747,7 @@
       },
       {
         "evalPath": "agent-037-updatetag-cache",
+        "costUsd": 0.08327963000000001,
         "result": {
           "success": true,
           "duration": 231559,
@@ -5252,6 +5757,7 @@
       },
       {
         "evalPath": "agent-038-refresh-settings",
+        "costUsd": 0.080720795,
         "result": {
           "success": true,
           "duration": 190378.5,
@@ -5261,6 +5767,7 @@
       },
       {
         "evalPath": "agent-039-indirect-proxy",
+        "costUsd": 0.03275566,
         "result": {
           "success": true,
           "duration": 173169,
@@ -5280,6 +5787,7 @@
       },
       {
         "evalPath": "agent-041-optimize-ppr-shell",
+        "costUsd": 0.17158792,
         "result": {
           "success": true,
           "duration": 307590,
@@ -5289,6 +5797,7 @@
       },
       {
         "evalPath": "agent-042-enable-ppr",
+        "costUsd": 0.08019095,
         "result": {
           "success": true,
           "duration": 194061,
@@ -5298,6 +5807,7 @@
       },
       {
         "evalPath": "agent-043-view-transitions",
+        "costUsd": 0.10992206,
         "result": {
           "success": true,
           "duration": 260036,
@@ -5309,6 +5819,7 @@
     "kimi-k3": [
       {
         "evalPath": "agent-000-app-router-migration-simple",
+        "costUsd": 0.2416782,
         "result": {
           "success": true,
           "duration": 259266.00000000003,
@@ -5318,6 +5829,7 @@
       },
       {
         "evalPath": "agent-021-avoid-fetch-in-effect",
+        "costUsd": 0.1283254,
         "result": {
           "success": true,
           "duration": 148257.3333333333,
@@ -5327,6 +5839,7 @@
       },
       {
         "evalPath": "agent-022-prefer-server-actions",
+        "costUsd": 0.0933504,
         "result": {
           "success": true,
           "duration": 103550.33333333331,
@@ -5336,6 +5849,7 @@
       },
       {
         "evalPath": "agent-023-avoid-getserversideprops",
+        "costUsd": 0.157821,
         "result": {
           "success": true,
           "duration": 190793,
@@ -5345,6 +5859,7 @@
       },
       {
         "evalPath": "agent-024-avoid-redundant-usestate",
+        "costUsd": 0.039973800000000004,
         "result": {
           "success": true,
           "duration": 137592,
@@ -5354,6 +5869,7 @@
       },
       {
         "evalPath": "agent-025-prefer-next-link",
+        "costUsd": 0.0663552,
         "result": {
           "success": true,
           "duration": 175181,
@@ -5363,6 +5879,7 @@
       },
       {
         "evalPath": "agent-026-no-serial-await",
+        "costUsd": 0.1796772,
         "result": {
           "success": true,
           "duration": 233589,
@@ -5372,6 +5889,7 @@
       },
       {
         "evalPath": "agent-027-prefer-next-image",
+        "costUsd": 0.093585,
         "result": {
           "success": true,
           "duration": 96391,
@@ -5381,6 +5899,7 @@
       },
       {
         "evalPath": "agent-028-prefer-next-font",
+        "costUsd": 0.11898179999999998,
         "result": {
           "success": true,
           "duration": 174955,
@@ -5390,6 +5909,7 @@
       },
       {
         "evalPath": "agent-029-use-cache-directive",
+        "costUsd": 0.2817543,
         "result": {
           "success": true,
           "duration": 237764.5,
@@ -5399,6 +5919,7 @@
       },
       {
         "evalPath": "agent-030-app-router-migration-hard",
+        "costUsd": 0.25723844999999995,
         "result": {
           "success": true,
           "duration": 222416.25,
@@ -5408,6 +5929,7 @@
       },
       {
         "evalPath": "agent-031-proxy-middleware",
+        "costUsd": 0.0964266,
         "result": {
           "success": true,
           "duration": 164131,
@@ -5417,6 +5939,7 @@
       },
       {
         "evalPath": "agent-032-use-cache-directive",
+        "costUsd": 0.111228,
         "result": {
           "success": true,
           "duration": 117914.5,
@@ -5426,6 +5949,7 @@
       },
       {
         "evalPath": "agent-033-forbidden-auth",
+        "costUsd": 0.1284606,
         "result": {
           "success": true,
           "duration": 217980,
@@ -5435,6 +5959,7 @@
       },
       {
         "evalPath": "agent-034-async-cookies",
+        "costUsd": 0.0925686,
         "result": {
           "success": true,
           "duration": 205673,
@@ -5444,6 +5969,7 @@
       },
       {
         "evalPath": "agent-035-connection-dynamic",
+        "costUsd": 0.1241958,
         "result": {
           "success": true,
           "duration": 205041,
@@ -5453,6 +5979,7 @@
       },
       {
         "evalPath": "agent-036-after-response",
+        "costUsd": 0.1288416,
         "result": {
           "success": true,
           "duration": 177178,
@@ -5462,6 +5989,7 @@
       },
       {
         "evalPath": "agent-037-updatetag-cache",
+        "costUsd": 0.20522159999999998,
         "result": {
           "success": true,
           "duration": 248774,
@@ -5471,6 +5999,7 @@
       },
       {
         "evalPath": "agent-038-refresh-settings",
+        "costUsd": 0.13669679999999998,
         "result": {
           "success": true,
           "duration": 188220,
@@ -5480,6 +6009,7 @@
       },
       {
         "evalPath": "agent-039-indirect-proxy",
+        "costUsd": 0.05430179999999999,
         "result": {
           "success": true,
           "duration": 96564.66666666666,
@@ -5489,6 +6019,7 @@
       },
       {
         "evalPath": "agent-040-instant",
+        "costUsd": 0.12444134999999998,
         "result": {
           "success": false,
           "duration": 199647.25,
@@ -5498,6 +6029,7 @@
       },
       {
         "evalPath": "agent-041-optimize-ppr-shell",
+        "costUsd": 0.5093424,
         "result": {
           "success": true,
           "duration": 419089,
@@ -5507,6 +6039,7 @@
       },
       {
         "evalPath": "agent-042-enable-ppr",
+        "costUsd": 0.09239939999999999,
         "result": {
           "success": true,
           "duration": 160646,
@@ -5516,6 +6049,7 @@
       },
       {
         "evalPath": "agent-043-view-transitions",
+        "costUsd": 0.1838832,
         "result": {
           "success": true,
           "duration": 189276.5,
@@ -5527,6 +6061,7 @@
     "minimax-m2.7": [
       {
         "evalPath": "agent-000-app-router-migration-simple",
+        "costUsd": 0.054857699999999995,
         "result": {
           "success": true,
           "duration": 344848,
@@ -5536,6 +6071,7 @@
       },
       {
         "evalPath": "agent-021-avoid-fetch-in-effect",
+        "costUsd": 0.010122540000000001,
         "result": {
           "success": true,
           "duration": 319153,
@@ -5545,6 +6081,7 @@
       },
       {
         "evalPath": "agent-022-prefer-server-actions",
+        "costUsd": 0.0060318,
         "result": {
           "success": true,
           "duration": 284077,
@@ -5554,6 +6091,7 @@
       },
       {
         "evalPath": "agent-023-avoid-getserversideprops",
+        "costUsd": 0.00413502,
         "result": {
           "success": true,
           "duration": 259920.00000000003,
@@ -5563,6 +6101,7 @@
       },
       {
         "evalPath": "agent-024-avoid-redundant-usestate",
+        "costUsd": 0.00285114,
         "result": {
           "success": true,
           "duration": 256153.00000000003,
@@ -5572,6 +6111,7 @@
       },
       {
         "evalPath": "agent-025-prefer-next-link",
+        "costUsd": 0.00652296,
         "result": {
           "success": true,
           "duration": 292908,
@@ -5581,6 +6121,7 @@
       },
       {
         "evalPath": "agent-026-no-serial-await",
+        "costUsd": 0.0032519399999999996,
         "result": {
           "success": true,
           "duration": 321139.6666666667,
@@ -5590,6 +6131,7 @@
       },
       {
         "evalPath": "agent-027-prefer-next-image",
+        "costUsd": 0.00633258,
         "result": {
           "success": true,
           "duration": 299698,
@@ -5599,6 +6141,7 @@
       },
       {
         "evalPath": "agent-028-prefer-next-font",
+        "costUsd": 0.0032411999999999996,
         "result": {
           "success": false,
           "duration": 258671.74999999997,
@@ -5608,6 +6151,7 @@
       },
       {
         "evalPath": "agent-029-use-cache-directive",
+        "costUsd": 0.06254520000000001,
         "result": {
           "success": true,
           "duration": 346131.6666666667,
@@ -5617,6 +6161,7 @@
       },
       {
         "evalPath": "agent-030-app-router-migration-hard",
+        "costUsd": 0.05071752,
         "result": {
           "success": true,
           "duration": 403448,
@@ -5626,6 +6171,7 @@
       },
       {
         "evalPath": "agent-031-proxy-middleware",
+        "costUsd": 0.00437061,
         "result": {
           "success": false,
           "duration": 296038,
@@ -5635,6 +6181,7 @@
       },
       {
         "evalPath": "agent-032-use-cache-directive",
+        "costUsd": 0.0062736075,
         "result": {
           "success": false,
           "duration": 313372.5,
@@ -5644,6 +6191,7 @@
       },
       {
         "evalPath": "agent-033-forbidden-auth",
+        "costUsd": 0.02612856,
         "result": {
           "success": true,
           "duration": 334280,
@@ -5653,6 +6201,7 @@
       },
       {
         "evalPath": "agent-034-async-cookies",
+        "costUsd": 0.01362222,
         "result": {
           "success": true,
           "duration": 288422,
@@ -5662,6 +6211,7 @@
       },
       {
         "evalPath": "agent-035-connection-dynamic",
+        "costUsd": 0.06382714499999999,
         "result": {
           "success": false,
           "duration": 348731.5,
@@ -5671,6 +6221,7 @@
       },
       {
         "evalPath": "agent-036-after-response",
+        "costUsd": 0.019608599999999997,
         "result": {
           "success": true,
           "duration": 263986,
@@ -5680,6 +6231,7 @@
       },
       {
         "evalPath": "agent-037-updatetag-cache",
+        "costUsd": 0.019332749999999996,
         "result": {
           "success": false,
           "duration": 294713.49999999994,
@@ -5689,6 +6241,7 @@
       },
       {
         "evalPath": "agent-038-refresh-settings",
+        "costUsd": 0.005168835,
         "result": {
           "success": false,
           "duration": 342662.74999999994,
@@ -5698,6 +6251,7 @@
       },
       {
         "evalPath": "agent-039-indirect-proxy",
+        "costUsd": 0.0036415650000000003,
         "result": {
           "success": false,
           "duration": 286061.74999999994,
@@ -5717,6 +6271,7 @@
       },
       {
         "evalPath": "agent-041-optimize-ppr-shell",
+        "costUsd": 0.023982899999999998,
         "result": {
           "success": true,
           "duration": 144720.5,
@@ -5726,6 +6281,7 @@
       },
       {
         "evalPath": "agent-042-enable-ppr",
+        "costUsd": 0.00343875,
         "result": {
           "success": false,
           "duration": 68016.50000000001,
@@ -5735,6 +6291,7 @@
       },
       {
         "evalPath": "agent-043-view-transitions",
+        "costUsd": 0.09920387249999998,
         "result": {
           "success": true,
           "duration": 318507,
@@ -5746,6 +6303,7 @@
     "minimax-m3": [
       {
         "evalPath": "agent-000-app-router-migration-simple",
+        "costUsd": 0.09159126,
         "result": {
           "success": true,
           "duration": 267321,
@@ -5755,6 +6313,7 @@
       },
       {
         "evalPath": "agent-021-avoid-fetch-in-effect",
+        "costUsd": 0.0354384,
         "result": {
           "success": true,
           "duration": 168835,
@@ -5764,6 +6323,7 @@
       },
       {
         "evalPath": "agent-022-prefer-server-actions",
+        "costUsd": 0.01678074,
         "result": {
           "success": true,
           "duration": 147837,
@@ -5773,6 +6333,7 @@
       },
       {
         "evalPath": "agent-023-avoid-getserversideprops",
+        "costUsd": 0.0246948,
         "result": {
           "success": true,
           "duration": 166348,
@@ -5782,6 +6343,7 @@
       },
       {
         "evalPath": "agent-024-avoid-redundant-usestate",
+        "costUsd": 0.007485779999999999,
         "result": {
           "success": true,
           "duration": 125190,
@@ -5791,6 +6353,7 @@
       },
       {
         "evalPath": "agent-025-prefer-next-link",
+        "costUsd": 0.01746714,
         "result": {
           "success": true,
           "duration": 145327,
@@ -5800,6 +6363,7 @@
       },
       {
         "evalPath": "agent-026-no-serial-await",
+        "costUsd": 0.015412799999999999,
         "result": {
           "success": true,
           "duration": 144165,
@@ -5809,6 +6373,7 @@
       },
       {
         "evalPath": "agent-027-prefer-next-image",
+        "costUsd": 0.0214854,
         "result": {
           "success": true,
           "duration": 138285,
@@ -5818,6 +6383,7 @@
       },
       {
         "evalPath": "agent-028-prefer-next-font",
+        "costUsd": 0.010604759999999998,
         "result": {
           "success": true,
           "duration": 132657,
@@ -5827,6 +6393,7 @@
       },
       {
         "evalPath": "agent-029-use-cache-directive",
+        "costUsd": 0.08466997999999999,
         "result": {
           "success": true,
           "duration": 325463,
@@ -5836,6 +6403,7 @@
       },
       {
         "evalPath": "agent-030-app-router-migration-hard",
+        "costUsd": 0.42626664000000003,
         "result": {
           "success": true,
           "duration": 637677,
@@ -5845,6 +6413,7 @@
       },
       {
         "evalPath": "agent-031-proxy-middleware",
+        "costUsd": 0.009312540000000001,
         "result": {
           "success": true,
           "duration": 134680,
@@ -5854,6 +6423,7 @@
       },
       {
         "evalPath": "agent-032-use-cache-directive",
+        "costUsd": 0.034855739999999996,
         "result": {
           "success": true,
           "duration": 189605,
@@ -5863,6 +6433,7 @@
       },
       {
         "evalPath": "agent-033-forbidden-auth",
+        "costUsd": 0.01181196,
         "result": {
           "success": true,
           "duration": 151969,
@@ -5872,6 +6443,7 @@
       },
       {
         "evalPath": "agent-034-async-cookies",
+        "costUsd": 0.011569020000000001,
         "result": {
           "success": true,
           "duration": 124650,
@@ -5881,6 +6453,7 @@
       },
       {
         "evalPath": "agent-035-connection-dynamic",
+        "costUsd": 0.007929539999999999,
         "result": {
           "success": true,
           "duration": 124226,
@@ -5890,6 +6463,7 @@
       },
       {
         "evalPath": "agent-036-after-response",
+        "costUsd": 0.00924702,
         "result": {
           "success": true,
           "duration": 121184,
@@ -5899,6 +6473,7 @@
       },
       {
         "evalPath": "agent-037-updatetag-cache",
+        "costUsd": 0.01288284,
         "result": {
           "success": true,
           "duration": 143881,
@@ -5908,6 +6483,7 @@
       },
       {
         "evalPath": "agent-038-refresh-settings",
+        "costUsd": 0.030433799999999997,
         "result": {
           "success": true,
           "duration": 154029,
@@ -5917,6 +6493,7 @@
       },
       {
         "evalPath": "agent-039-indirect-proxy",
+        "costUsd": 0.00775122,
         "result": {
           "success": true,
           "duration": 122375,
@@ -5936,6 +6513,7 @@
       },
       {
         "evalPath": "agent-041-optimize-ppr-shell",
+        "costUsd": 0.14120352000000003,
         "result": {
           "success": true,
           "duration": 525458,
@@ -5945,6 +6523,7 @@
       },
       {
         "evalPath": "agent-042-enable-ppr",
+        "costUsd": 0.00634224,
         "result": {
           "success": true,
           "duration": 110108,
@@ -5954,6 +6533,7 @@
       },
       {
         "evalPath": "agent-043-view-transitions",
+        "costUsd": 0.06312114,
         "result": {
           "success": true,
           "duration": 191029.5,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "eval": "agent-eval",
     "sync-evals": "tsx scripts/sync-evals.ts",
-    "export-results": "tsx scripts/export-results.ts"
+    "export-results": "tsx scripts/export-results.ts",
+    "test:cost": "tsx --test scripts/cost.test.ts"
   },
   "devDependencies": {
     "tsx": "^4.19.0",

--- a/results/gpt-5.4-xhigh--agents-md/openai/gpt-5.4?reasoningEffort=xhigh/2026-07-17T19-18-24.998Z/agent-030-app-router-migration-hard/run-1/result.json
+++ b/results/gpt-5.4-xhigh--agents-md/openai/gpt-5.4?reasoningEffort=xhigh/2026-07-17T19-18-24.998Z/agent-030-app-router-migration-hard/run-1/result.json
@@ -1,0 +1,6 @@
+{
+  "status": "failed",
+  "error": "Eval timed out after 720s",
+  "duration": 720.005,
+  "model": "openai/gpt-5.4?reasoningEffort=xhigh"
+}

--- a/results/gpt-5.4-xhigh--agents-md/openai/gpt-5.4?reasoningEffort=xhigh/2026-07-17T19-18-24.998Z/agent-030-app-router-migration-hard/run-2/result.json
+++ b/results/gpt-5.4-xhigh--agents-md/openai/gpt-5.4?reasoningEffort=xhigh/2026-07-17T19-18-24.998Z/agent-030-app-router-migration-hard/run-2/result.json
@@ -1,0 +1,6 @@
+{
+  "status": "failed",
+  "error": "Eval timed out after 720s",
+  "duration": 720.005,
+  "model": "openai/gpt-5.4?reasoningEffort=xhigh"
+}

--- a/results/gpt-5.4-xhigh--agents-md/openai/gpt-5.4?reasoningEffort=xhigh/2026-07-17T19-18-24.998Z/agent-030-app-router-migration-hard/run-3/result.json
+++ b/results/gpt-5.4-xhigh--agents-md/openai/gpt-5.4?reasoningEffort=xhigh/2026-07-17T19-18-24.998Z/agent-030-app-router-migration-hard/run-3/result.json
@@ -1,0 +1,6 @@
+{
+  "status": "failed",
+  "error": "Eval timed out after 720s",
+  "duration": 720.005,
+  "model": "openai/gpt-5.4?reasoningEffort=xhigh"
+}

--- a/results/gpt-5.4-xhigh--agents-md/openai/gpt-5.4?reasoningEffort=xhigh/2026-07-17T19-18-24.998Z/agent-030-app-router-migration-hard/run-4/result.json
+++ b/results/gpt-5.4-xhigh--agents-md/openai/gpt-5.4?reasoningEffort=xhigh/2026-07-17T19-18-24.998Z/agent-030-app-router-migration-hard/run-4/result.json
@@ -1,0 +1,6 @@
+{
+  "status": "failed",
+  "error": "Eval timed out after 720s",
+  "duration": 720.006,
+  "model": "openai/gpt-5.4?reasoningEffort=xhigh"
+}

--- a/results/gpt-5.4-xhigh--agents-md/openai/gpt-5.4?reasoningEffort=xhigh/2026-07-17T19-18-24.998Z/agent-030-app-router-migration-hard/summary.json
+++ b/results/gpt-5.4-xhigh--agents-md/openai/gpt-5.4?reasoningEffort=xhigh/2026-07-17T19-18-24.998Z/agent-030-app-router-migration-hard/summary.json
@@ -1,0 +1,6 @@
+{
+  "totalRuns": 4,
+  "passedRuns": 0,
+  "passRate": "0%",
+  "meanDuration": 720.0052499999999
+}

--- a/scripts/cost.test.ts
+++ b/scripts/cost.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for token extraction + pricing. Run with: pnpm test:cost
+ *
+ * The load-bearing case is claude-code dedupe: one API response is split across
+ * content-block events that repeat the same message.id + usage, so summing
+ * naively double-counts (~2.5x observed). Everything else is one golden fixture
+ * per harness format.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { extractRunTokens, priceUsage, MODEL_PRICING } from './cost.ts';
+
+const jsonl = (...events: unknown[]): string =>
+  events.map((e) => JSON.stringify(e)).join('\n');
+
+test('codex: single turn.completed, input includes cached', () => {
+  const raw = jsonl({
+    type: 'turn.completed',
+    usage: {
+      input_tokens: 1000,
+      cached_input_tokens: 800,
+      output_tokens: 50,
+      reasoning_output_tokens: 20,
+    },
+  });
+  // uncached input = 1000 - 800; cacheRead = 800; output as reported (200 incl reasoning)
+  assert.deepEqual(extractRunTokens(raw), {
+    input: 200,
+    output: 50,
+    cacheRead: 800,
+    cacheWrite: 0,
+  });
+});
+
+test('opencode: sums step-finish parts, reasoning billed as output', () => {
+  const raw = jsonl(
+    { type: 'step_finish', part: { type: 'step-finish', tokens: { input: 10, output: 5, reasoning: 3, cache: { read: 100, write: 2 } } } },
+    { type: 'step_finish', part: { type: 'step-finish', tokens: { input: 20, output: 7, reasoning: 0, cache: { read: 200, write: 0 } } } },
+  );
+  assert.deepEqual(extractRunTokens(raw), {
+    input: 30,
+    output: 15,
+    cacheRead: 300,
+    cacheWrite: 2,
+  });
+});
+
+test('claude-code: dedupe repeated message.id (no double-count)', () => {
+  const usage = {
+    input_tokens: 1,
+    output_tokens: 327,
+    cache_read_input_tokens: 32176,
+    cache_creation_input_tokens: 0,
+  };
+  // Same response emitted 4x (text block, tool_use block, ...), then a 2nd response.
+  const raw = jsonl(
+    { type: 'assistant', message: { id: 'gen_A', usage } },
+    { type: 'assistant', message: { id: 'gen_A', usage } },
+    { type: 'assistant', message: { id: 'gen_A', usage } },
+    { type: 'assistant', message: { id: 'gen_A', usage } },
+    { type: 'assistant', message: { id: 'gen_B', usage: { input_tokens: 2, output_tokens: 10, cache_read_input_tokens: 40000, cache_creation_input_tokens: 100 } } },
+  );
+  assert.deepEqual(extractRunTokens(raw), {
+    input: 1 + 2,
+    output: 327 + 10,
+    cacheRead: 32176 + 40000,
+    cacheWrite: 0 + 100,
+  });
+});
+
+test('gemini: final result.stats (input excludes cache)', () => {
+  const raw = jsonl({
+    type: 'result',
+    stats: { input_tokens: 95082, input: 18732, cached: 76350, output_tokens: 1072 },
+  });
+  assert.deepEqual(extractRunTokens(raw), {
+    input: 18732,
+    output: 1072,
+    cacheRead: 76350,
+    cacheWrite: 0,
+  });
+});
+
+test('cursor: result.usage, inputTokens is uncached', () => {
+  const raw = jsonl({
+    type: 'result',
+    usage: { inputTokens: 12280, outputTokens: 1976, cacheReadTokens: 114916, cacheWriteTokens: 0 },
+  });
+  assert.deepEqual(extractRunTokens(raw), {
+    input: 12280,
+    output: 1976,
+    cacheRead: 114916,
+    cacheWrite: 0,
+  });
+});
+
+test('no usage (e.g. timeout) returns null', () => {
+  assert.equal(extractRunTokens(''), null);
+  assert.equal(extractRunTokens(jsonl({ type: 'result', subtype: 'success', is_error: false })), null);
+});
+
+test('priceUsage: cache-heavy Claude run', () => {
+  // Fable 5 rates: 10 / 50 / 1 / 12.5 per 1M
+  const cost = priceUsage(
+    { input: 0, output: 20000, cacheRead: 1_000_000, cacheWrite: 200_000 },
+    MODEL_PRICING['claude-fable-5']!,
+  );
+  // 20000*50 + 1e6*1 + 200000*12.5 = 1e6 + 1e6 + 2.5e6 = 4.5e6 tok-$ / 1e6 = $4.50
+  assert.equal(cost, 4.5);
+});
+
+test('cursor-composer-1.5 is N/A (null price)', () => {
+  assert.equal(MODEL_PRICING['cursor-composer-1.5'], null);
+});

--- a/scripts/cost.ts
+++ b/scripts/cost.ts
@@ -63,7 +63,7 @@ export const MODEL_PRICING: Record<string, Pricing | null> = {
   'kimi-k3': { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 0 },
   'glm-5.1-opencode': { input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 },
   'glm-5.2': { input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 },
-  'grok-4.5': { input: 2, output: 6, cacheRead: 0.5, cacheWrite: 0 },
+  'grok-4.5': { input: 2, output: 6, cacheRead: 0.3, cacheWrite: 0 },
   'minimax-m2.7': { input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0.375 },
   'minimax-m3': { input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0 },
 };

--- a/scripts/cost.ts
+++ b/scripts/cost.ts
@@ -1,0 +1,189 @@
+/**
+ * List-cost estimation for nextjs.org/evals.
+ *
+ * Tokens are extracted from each run's transcript-raw.jsonl and multiplied by
+ * public list prices. Two halves, deliberately separated: token counts are
+ * facts about a run and never change; prices do, so they live in one table
+ * that is refreshed when a re-export runs.
+ *
+ * "List cost" means the published per-token rate, not a negotiated or
+ * subscription rate — a buyer comparing models at today's rack prices.
+ */
+
+/** Token usage for one run, normalized across agent harnesses. */
+export interface Usage {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+}
+
+/** List price per 1M tokens. */
+export interface Pricing {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+}
+
+/**
+ * List prices per 1M tokens, keyed by the board (base) experiment slug.
+ * --agents-md variants resolve to the same entry via AGENTS_MD_PAIRS.
+ *
+ * Anthropic / Google / OpenAI / Moonshot / Z.ai / xAI / MiniMax values are a
+ * snapshot of models.dev. Cursor Composer is not on models.dev; its rates come
+ * from cursor.com/docs/models-and-pricing (Standard tier).
+ *
+ * null = do not estimate a cost (rendered as N/A). cursor-composer-1.5 is null
+ * because its February CLI wrote no token usage to the transcript, so there is
+ * nothing to price.
+ *
+ * When adding a model, add its price here or /evals shows N/A for that row.
+ */
+export const MODEL_PRICING: Record<string, Pricing | null> = {
+  'claude-fable-5': { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
+  'claude-opus-4.6': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+  'claude-opus-4.7': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+  'claude-opus-4.8': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+  'claude-sonnet-4.5': { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+  'claude-sonnet-4.6': { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+  'cursor-composer-1.5': null, // Feb CLI emitted no token usage
+  'cursor-composer-2.0': { input: 0.5, output: 2.5, cacheRead: 0.2, cacheWrite: 0 }, // cursor.com, Standard
+  'cursor-composer-2.5': { input: 0.5, output: 2.5, cacheRead: 0.2, cacheWrite: 0 }, // cursor.com, Standard
+  'gemini-3-pro-preview-gemini-cli': { input: 2, output: 12, cacheRead: 0.2, cacheWrite: 0 },
+  'gemini-3.1-pro-preview': { input: 2, output: 12, cacheRead: 0.2, cacheWrite: 0 },
+  'gpt-5.2-codex-xhigh': { input: 1.75, output: 14, cacheRead: 0.175, cacheWrite: 0 },
+  'gpt-5.3-codex-xhigh': { input: 1.75, output: 14, cacheRead: 0.175, cacheWrite: 0 },
+  'gpt-5.4-xhigh': { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 },
+  'gpt-5.5-pro': { input: 30, output: 180, cacheRead: 0, cacheWrite: 0 }, // never caches; cacheRead moot
+  'gpt-5.6-sol-ultra': { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 },
+  'kimi-k2.5': { input: 0.6, output: 3, cacheRead: 0.1, cacheWrite: 0 },
+  'kimi-k2.6': { input: 0.95, output: 4, cacheRead: 0.16, cacheWrite: 0 },
+  'kimi-k2.7-code': { input: 0.95, output: 4, cacheRead: 0.19, cacheWrite: 0 },
+  'kimi-k3': { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 0 },
+  'glm-5.1-opencode': { input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 },
+  'glm-5.2': { input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 },
+  'grok-4.5': { input: 2, output: 6, cacheRead: 0.5, cacheWrite: 0 },
+  'minimax-m2.7': { input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0.375 },
+  'minimax-m3': { input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0 },
+};
+
+/** USD for one run at the given list price. */
+export function priceUsage(u: Usage, p: Pricing): number {
+  return (
+    (u.input * p.input +
+      u.output * p.output +
+      u.cacheRead * p.cacheRead +
+      u.cacheWrite * p.cacheWrite) /
+    1_000_000
+  );
+}
+
+const num = (v: unknown): number => (typeof v === 'number' ? v : 0);
+const obj = (v: unknown): Record<string, unknown> =>
+  v && typeof v === 'object' ? (v as Record<string, unknown>) : {};
+
+function parseLines(raw: string): Array<Record<string, unknown>> {
+  const events: Array<Record<string, unknown>> = [];
+  for (const line of raw.split('\n')) {
+    const t = line.trim();
+    if (!t) continue;
+    try {
+      events.push(JSON.parse(t));
+    } catch {
+      // skip non-JSON lines
+    }
+  }
+  return events;
+}
+
+/**
+ * Extract normalized token usage from one run's raw transcript. Returns null
+ * if the transcript carries no usage (e.g. a timed-out run saves none, and the
+ * old Cursor CLI never wrote any).
+ *
+ * The format is sniffed from event shape rather than passed in, so it stays
+ * correct as harnesses are added:
+ * - codex: one `turn.completed` with cumulative usage; input_tokens includes
+ *   cached_input_tokens, so uncached input = input_tokens - cached.
+ * - opencode: per `step-finish` part; reasoning tokens billed as output.
+ * - claude-code: one API response spans several content-block events that
+ *   repeat the same message.id + usage — dedupe by id (max per field) or it
+ *   double-counts (~2.5x). input_tokens excludes cache.
+ * - gemini: final `result.stats` (input excludes cache; cached separate).
+ * - cursor: final `result.usage` with inputTokens/outputTokens/cacheReadTokens.
+ */
+export function extractRunTokens(raw: string): Usage | null {
+  const events = parseLines(raw);
+  const u: Usage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+  let got = false;
+  const claudeById = new Map<string, Usage>();
+
+  for (const d of events) {
+    const type = d.type as string | undefined;
+
+    if (type === 'turn.completed' && d.usage) {
+      const x = obj(d.usage);
+      const cached = num(x.cached_input_tokens);
+      u.input += num(x.input_tokens) - cached;
+      u.cacheRead += cached;
+      u.output += num(x.output_tokens);
+      got = true;
+    } else if (type === 'step_finish' && d.part) {
+      const p = obj(d.part);
+      if (p.type === 'step-finish') {
+        const tk = obj(p.tokens);
+        const c = obj(tk.cache);
+        u.input += num(tk.input);
+        u.output += num(tk.output) + num(tk.reasoning);
+        u.cacheRead += num(c.read);
+        u.cacheWrite += num(c.write);
+        got = true;
+      }
+    } else if (type === 'assistant') {
+      const msg = obj(d.message);
+      const x = msg.usage ? obj(msg.usage) : undefined;
+      if (x) {
+        got = true;
+        const mid = (msg.id as string) ?? String(claudeById.size);
+        const prev = claudeById.get(mid) ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+        claudeById.set(mid, {
+          input: Math.max(prev.input, num(x.input_tokens)),
+          cacheRead: Math.max(prev.cacheRead, num(x.cache_read_input_tokens)),
+          cacheWrite: Math.max(prev.cacheWrite, num(x.cache_creation_input_tokens)),
+          output: Math.max(prev.output, num(x.output_tokens)),
+        });
+      }
+    } else if (type === 'result') {
+      const stats = obj(d.stats);
+      const usage = obj(d.usage);
+      if (stats.input_tokens !== undefined) {
+        return {
+          input: num(stats.input),
+          cacheRead: num(stats.cached),
+          cacheWrite: 0,
+          output: num(stats.output_tokens),
+        };
+      }
+      if (usage.inputTokens !== undefined) {
+        // Cursor: inputTokens is uncached; cacheReadTokens is separate.
+        u.input += num(usage.inputTokens);
+        u.cacheRead += num(usage.cacheReadTokens);
+        u.cacheWrite += num(usage.cacheWriteTokens);
+        u.output += num(usage.outputTokens);
+        got = true;
+      }
+    }
+  }
+
+  if (claudeById.size > 0) {
+    for (const mu of claudeById.values()) {
+      u.input += mu.input;
+      u.output += mu.output;
+      u.cacheRead += mu.cacheRead;
+      u.cacheWrite += mu.cacheWrite;
+    }
+  }
+
+  return got ? u : null;
+}

--- a/scripts/export-results.ts
+++ b/scripts/export-results.ts
@@ -14,6 +14,7 @@
 import { execSync } from 'node:child_process';
 import { readdir, readFile, writeFile, stat } from 'node:fs/promises';
 import { join } from 'node:path';
+import { MODEL_PRICING, extractRunTokens, priceUsage } from './cost.js';
 
 interface SummaryJson {
   totalRuns: number;
@@ -28,12 +29,94 @@ interface AgentResult {
   // eval's content changed since). Counts against the success rate so every
   // experiment is scored over the same canonical eval set.
   notAvailable?: boolean;
+  // Mean list cost in USD across this eval's runs, or undefined when the run
+  // saved no token usage (e.g. a timeout) or the model has no price entry.
+  costUsd?: number;
   result: {
     success: boolean;
     duration: number;
     evalPath: string;
     timestamp: string;
   };
+}
+
+// variant → base experiment (same agent harness). Hoisted to module scope so
+// both cost pricing (per eval) and the docs-impact merge resolve the same base.
+const AGENTS_MD_PAIRS: Record<string, string> = {
+  'claude-fable-5--agents-md': 'claude-fable-5',
+  'claude-opus-4.6--agents-md': 'claude-opus-4.6',
+  'claude-opus-4.7--agents-md': 'claude-opus-4.7',
+  'claude-opus-4.8--agents-md': 'claude-opus-4.8',
+  'claude-sonnet-4.5--agents-md': 'claude-sonnet-4.5',
+  'claude-sonnet-4.6--agents-md': 'claude-sonnet-4.6',
+  'cursor-composer-1.5--agents-md': 'cursor-composer-1.5',
+  'cursor-composer-2.0--agents-md': 'cursor-composer-2.0',
+  'cursor-composer-2.5--agents-md': 'cursor-composer-2.5',
+  'gemini-3-pro-preview--agents-md': 'gemini-3-pro-preview-gemini-cli',
+  'gemini-3.1-pro-preview--agents-md': 'gemini-3.1-pro-preview',
+  'gpt-5.2-codex-xhigh--agents-md': 'gpt-5.2-codex-xhigh',
+  'gpt-5.3-codex-xhigh--agents-md': 'gpt-5.3-codex-xhigh',
+  'gpt-5.4-xhigh--agents-md': 'gpt-5.4-xhigh',
+  'gpt-5.5-pro--agents-md': 'gpt-5.5-pro',
+  'gpt-5.6-sol-ultra--agents-md': 'gpt-5.6-sol-ultra',
+  'kimi-k2.5--agents-md': 'kimi-k2.5',
+  'kimi-k2.6--agents-md': 'kimi-k2.6',
+  'kimi-k2.7-code--agents-md': 'kimi-k2.7-code',
+  'kimi-k3--agents-md': 'kimi-k3',
+  'minimax-m2.7--agents-md': 'minimax-m2.7',
+  'minimax-m3--agents-md': 'minimax-m3',
+  'glm-5.1-opencode--agents-md': 'glm-5.1-opencode',
+  'glm-5.2--agents-md': 'glm-5.2',
+  'grok-4.5--agents-md': 'grok-4.5',
+};
+
+/**
+ * Mean list cost (USD) for one eval, averaged over its runs. Reads each run's
+ * transcript-raw.jsonl, extracts tokens, and prices them at the experiment's
+ * list rate. Returns undefined when the model has no price or no run carried
+ * usage (e.g. a timeout), so the caller can leave it out of the average.
+ */
+async function meanEvalCostUsd(
+  evalDir: string,
+  experiment: string,
+): Promise<number | undefined> {
+  const baseSlug = AGENTS_MD_PAIRS[experiment] ?? experiment;
+  const pricing = MODEL_PRICING[baseSlug];
+  if (!pricing) return undefined;
+
+  let runEntries: string[];
+  try {
+    runEntries = await readdir(evalDir);
+  } catch {
+    return undefined;
+  }
+
+  const costs: number[] = [];
+  for (const entry of runEntries) {
+    if (!entry.startsWith('run-')) continue;
+    try {
+      const raw = await readFile(join(evalDir, entry, 'transcript-raw.jsonl'), 'utf-8');
+      const usage = extractRunTokens(raw);
+      if (usage) costs.push(priceUsage(usage, pricing));
+    } catch {
+      // No transcript for this run (e.g. timeout) — skip it.
+    }
+  }
+
+  if (costs.length === 0) return undefined;
+  return costs.reduce((a, b) => a + b, 0) / costs.length;
+}
+
+/**
+ * Mean per-eval list cost across results, over cells that have a cost. Returns
+ * null when none do (so an all-timeout or unpriced experiment reads as N/A).
+ */
+function avgCost(results: AgentResult[]): number | null {
+  const costs = results
+    .filter((r) => !r.notAvailable && typeof r.costUsd === 'number')
+    .map((r) => r.costUsd as number);
+  if (costs.length === 0) return null;
+  return costs.reduce((a, b) => a + b, 0) / costs.length;
 }
 
 interface DocsImpact {
@@ -53,6 +136,9 @@ interface ExportedData {
       modelName: string;
       agentHarness: string;
       avgDuration?: number;
+      // Mean list cost per eval (USD). null = not estimated (no price, or the
+      // model's runs carry no usable token usage) — rendered as N/A.
+      avgCostUsd?: number | null;
       docsImpact?: DocsImpact;
     }>;
   };
@@ -270,8 +356,11 @@ async function main(): Promise<void> {
           // Skip invalid results (infra/timeout failures)
           if (summary.valid === false) continue;
 
+          const costUsd = await meanEvalCostUsd(join(runDir, evalDir), experiment);
+
           agentResults.push({
             evalPath: evalDir,
+            ...(costUsd !== undefined ? { costUsd } : {}),
             result: {
               success: summary.passedRuns > 0,
               duration: summary.meanDuration * 1000,
@@ -333,36 +422,8 @@ async function main(): Promise<void> {
     exportedData.results[experiment] = normalized;
   }
 
-  // Merge --agents-md variants into base experiments
-  // variant → base (must use the same agent harness)
-  const AGENTS_MD_PAIRS: Record<string, string> = {
-    'claude-fable-5--agents-md': 'claude-fable-5',
-    'claude-opus-4.6--agents-md': 'claude-opus-4.6',
-    'claude-opus-4.7--agents-md': 'claude-opus-4.7',
-    'claude-opus-4.8--agents-md': 'claude-opus-4.8',
-    'claude-sonnet-4.5--agents-md': 'claude-sonnet-4.5',
-    'claude-sonnet-4.6--agents-md': 'claude-sonnet-4.6',
-    'cursor-composer-1.5--agents-md': 'cursor-composer-1.5',
-    'cursor-composer-2.0--agents-md': 'cursor-composer-2.0',
-    'cursor-composer-2.5--agents-md': 'cursor-composer-2.5',
-    'gemini-3-pro-preview--agents-md': 'gemini-3-pro-preview-gemini-cli',
-    'gemini-3.1-pro-preview--agents-md': 'gemini-3.1-pro-preview',
-    'gpt-5.2-codex-xhigh--agents-md': 'gpt-5.2-codex-xhigh',
-    'gpt-5.3-codex-xhigh--agents-md': 'gpt-5.3-codex-xhigh',
-    'gpt-5.4-xhigh--agents-md': 'gpt-5.4-xhigh',
-    'gpt-5.5-pro--agents-md': 'gpt-5.5-pro',
-    'gpt-5.6-sol-ultra--agents-md': 'gpt-5.6-sol-ultra',
-    'kimi-k2.5--agents-md': 'kimi-k2.5',
-    'kimi-k2.6--agents-md': 'kimi-k2.6',
-    'kimi-k2.7-code--agents-md': 'kimi-k2.7-code',
-    'kimi-k3--agents-md': 'kimi-k3',
-    'minimax-m2.7--agents-md': 'minimax-m2.7',
-    'minimax-m3--agents-md': 'minimax-m3',
-    'glm-5.1-opencode--agents-md': 'glm-5.1-opencode',
-    'glm-5.2--agents-md': 'glm-5.2',
-    'grok-4.5--agents-md': 'grok-4.5',
-  };
-
+  // Merge --agents-md variants into base experiments (AGENTS_MD_PAIRS is
+  // defined at module scope so per-eval cost pricing resolves the same base).
   for (const [variantName, baseName] of Object.entries(AGENTS_MD_PAIRS)) {
     const baseExp = exportedData.metadata.experiments.find((e) => e.name === baseName);
     const variantExp = exportedData.metadata.experiments.find((e) => e.name === variantName);
@@ -424,6 +485,13 @@ async function main(): Promise<void> {
     baseExp.avgDuration =
       allDurationsMs.reduce((a, b) => a + b, 0) / allDurationsMs.length / 1000;
 
+    // Average list cost per eval across base + variant, over cells that have a
+    // cost (a timed-out eval has none and is simply left out). null when the
+    // model has no price at all → N/A on the board.
+    baseExp.avgCostUsd = MODEL_PRICING[baseName]
+      ? avgCost([...baseResults, ...variantResults])
+      : null;
+
     // Use the newer of base / variant timestamps
     if (new Date(variantExp.timestamp) > new Date(baseExp.timestamp)) {
       baseExp.timestamp = variantExp.timestamp;
@@ -442,17 +510,23 @@ async function main(): Promise<void> {
     delete exportedData.results[variantName];
   }
 
-  // Fill avgDuration for any experiments that didn't go through the merge
+  // Fill avgDuration / avgCostUsd for experiments that didn't go through the
+  // merge (standalone, no --agents-md pair).
   for (const exp of exportedData.metadata.experiments) {
-    if (exp.avgDuration !== undefined) continue;
     const results = exportedData.results[exp.name];
     if (!results || results.length === 0) continue;
-    const durations = results
-      .filter((r) => !r.notAvailable)
-      .map((r) => r.result.duration);
-    if (durations.length === 0) continue;
-    exp.avgDuration =
-      durations.reduce((a, b) => a + b, 0) / durations.length / 1000;
+    if (exp.avgDuration === undefined) {
+      const durations = results
+        .filter((r) => !r.notAvailable)
+        .map((r) => r.result.duration);
+      if (durations.length > 0) {
+        exp.avgDuration =
+          durations.reduce((a, b) => a + b, 0) / durations.length / 1000;
+      }
+    }
+    if (exp.avgCostUsd === undefined) {
+      exp.avgCostUsd = MODEL_PRICING[exp.name] ? avgCost(results) : null;
+    }
   }
 
   // Count stats


### PR DESCRIPTION
Adds `avgCostUsd` per experiment so nextjs.org/evals can show a list-cost column. `scripts/cost.ts` reads tokens from each run's `transcript-raw.jsonl` and prices them against a `MODEL_PRICING` snapshot (models.dev, plus Cursor from cursor.com). Cost is null (N/A) when a model has no price or its runs carry no usable tokens.

The extraction handles each harness's usage shape, verified against the committed transcripts. Two are easy to get wrong: codex `input_tokens` includes `cached_input_tokens` (uncached input is the difference), and claude-code repeats one response's `message.id` + usage across content-block events, so deduping by id avoids a ~2.5x overcount. cursor-composer-1.5 is N/A because its February CLI wrote no usage.

Regenerating `agent-results.json` changes only the added cost fields; success and N/A cells are unchanged. `scripts/cost.test.ts` locks the per-harness semantics (`pnpm test:cost`).

The one refreshed board cell (first commit) is gpt-5.4-xhigh x agent-030: its 2026-03-21 result was stale, and a rerun still times out 0/4 at 720s. A timed-out run saves no transcript, so that cell has no cost and drops out of the row average.