### PR TITLE
Port the eval suite to Harbor task format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ dist/
 /evals/
 .sync-tmp/
 .env*
+/harbor/tasks/
+jobs/

--- a/harbor/README.md
+++ b/harbor/README.md
@@ -62,6 +62,24 @@ harbor run -y -p harbor/tasks -a claude-code -m claude-sonnet-4-6 -k 4 \
 both pass, mirroring agent-eval's `allPassed`), plus `vitestPassed` /
 `buildPassed` for diagnosis.
 
+## Proven runs (2026-07-17, local Docker, harbor 0.19.0)
+
+| job           | agent                          | reward | vitestPassed | buildPassed | cost  |
+|---------------|--------------------------------|--------|--------------|-------------|-------|
+| nop-021       | nop (red-path proof)           | 0      | 0            | 1           | $0    |
+| claude-021    | claude-code, claude-sonnet-4-6 | 1      | 1            | 1           | $0.23 |
+| claude-034-v2 | claude-code, claude-sonnet-4-6 | 1      | 1            | 1           | $0.08 |
+
+claude-034 is one of the three LLM-judge evals: its judge invocation ran
+inside the verifier (19.7s on the judged test vs 236ms when the judge could
+not launch). The nop row shows the grader discriminates: the untouched
+scaffold builds but fails 2 of 5 EVAL.ts assertions.
+
+Gotcha found by these runs: harbor containers run the verifier as root, and
+Claude Code refuses `--dangerously-skip-permissions` as root. test.sh sets
+`IS_SANDBOX=1` (the same flag harbor's agent phase sets); agent-eval never
+hit this because its Vercel sandbox validation runs unprivileged.
+
 ## Not ported (yet)
 
 - The `--agents-md` experiment arm (injects `AGENTS.md` into the fixture) —

--- a/harbor/README.md
+++ b/harbor/README.md
@@ -45,9 +45,9 @@ host-env access prompt (required for non-interactive runs).
 Set `HARBOR_TELEMETRY=0` for every run. Harbor sends a PostHog event per job
 by default, and the payload includes `model_names`, `agent_names`, and
 `reward_mean` (`telemetry.py:115-117,151` at harbor 19f72aa). With
-unreleased or EAP model strings that is a leak. Job results themselves never
-leave the machine: `harbor run` only writes the local `jobs/` directory, and
-Hub sharing is a separate explicit command.
+unreleased or EAP model strings that is a leak. Job results stay in the
+local `jobs/` directory unless you pass `--upload`, which streams them to
+the Harbor Hub during the run. Never pass it for EAP work.
 
 ```bash
 export HARBOR_TELEMETRY=0

--- a/harbor/README.md
+++ b/harbor/README.md
@@ -1,0 +1,72 @@
+# Harbor port (spike)
+
+Runs the same evals as `@vercel/agent-eval` on
+[Harbor](https://www.harborframework.com/) (Laude Institute, the
+terminal-bench team). Companion to the framework-evals port; harness
+comparison lives in framework-evals `docs/harbor-assessment.md`.
+
+Both `evals/` and `harbor/tasks/` are generated, gitignored artifacts:
+
+```bash
+pnpm install
+pnpm sync-evals          # vercel/next.js@canary -> evals/  (existing flow)
+./harbor/sync-tasks.sh   # evals/ + templates    -> harbor/tasks/ (24 tasks)
+```
+
+## Layout mapping
+
+| agent-eval                            | harbor                                        |
+|---------------------------------------|-----------------------------------------------|
+| `evals/<eval>/PROMPT.md`              | `tasks/<eval>/instruction.md`                 |
+| `evals/<eval>/` fixture               | `tasks/<eval>/environment/workspace/`         |
+| `evals/<eval>/EVAL.ts` (withheld)     | `tasks/<eval>/tests/EVAL.ts` (uploaded post-run) |
+| experiments `setup()` canary bump     | `RUN npm install next@canary` in Dockerfile   |
+| experiments `scripts: ['build']`      | `npm run build` step in `tests/test.sh`       |
+| harness-written `vitest.config.ts`    | written by `tests/test.sh` (same content)     |
+| `eval-helper.mjs` + judge runner      | shipped in `tests/`, staged at `__agent_eval__/` |
+| experiments `timeout: 720`            | `task.toml` `[agent] timeout_sec = 720`       |
+
+## LLM-judge evals
+
+3 of 24 evals (`agent-030`, `agent-034`, `agent-041`) call
+`toSatisfyCriterion` from `@vercel/agent-eval/eval`, which re-invokes the
+claude CLI at grading time. `test.sh` stages the vendored `eval-helper.mjs`
+and `run.mjs` at the hard-coded `__agent_eval__/` paths, and `task.toml`
+`[verifier.env]` forwards `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` /
+`ANTHROPIC_MODEL` from the host (empty defaults keep credential-free runs
+working). The claude CLI installed for the agent phase is reused — the
+verifier runs in the same container.
+
+## Running
+
+Prereqs: Docker running, `uv tool install harbor`. `-y` auto-confirms the
+host-env access prompt (required for non-interactive runs).
+
+```bash
+# Red-path proof, no tokens: nop agent leaves the fixture unmodified.
+harbor run -y -p harbor/tasks/agent-021-avoid-fetch-in-effect -a nop --job-name nop-021
+
+# Real run through the Vercel AI Gateway (fresh VERCEL_OIDC_TOKEN, ~12h expiry).
+export ANTHROPIC_BASE_URL=https://ai-gateway.vercel.sh
+export ANTHROPIC_AUTH_TOKEN=$VERCEL_OIDC_TOKEN
+export ANTHROPIC_MODEL=claude-sonnet-4-6   # judge model for the 3 judge evals
+harbor run -y -p harbor/tasks/agent-034-async-cookies -a claude-code \
+  -m claude-sonnet-4-6 --job-name claude-034
+
+# Full suite, 4 attempts each (mirrors experiments' runs: 4)
+harbor run -y -p harbor/tasks -a claude-code -m claude-sonnet-4-6 -k 4 \
+  --job-name claude-suite
+```
+
+`reward.json` per trial: `reward` (1 iff vitest EVAL.ts and `npm run build`
+both pass, mirroring agent-eval's `allPassed`), plus `vitestPassed` /
+`buildPassed` for diagnosis.
+
+## Not ported (yet)
+
+- The `--agents-md` experiment arm (injects `AGENTS.md` into the fixture) —
+  a task variant or a second generated task set.
+- `earlyExit: true` semantics — harbor's `--n-attempts` always runs all
+  attempts.
+- `agent-eval status` / refingerprint bookkeeping and `export-results.ts`
+  publishing — results stay in harbor's `jobs/` shape.

--- a/harbor/README.md
+++ b/harbor/README.md
@@ -42,7 +42,16 @@ verifier runs in the same container.
 Prereqs: Docker running, `uv tool install harbor`. `-y` auto-confirms the
 host-env access prompt (required for non-interactive runs).
 
+Set `HARBOR_TELEMETRY=0` for every run. Harbor sends a PostHog event per job
+by default, and the payload includes `model_names`, `agent_names`, and
+`reward_mean` (`telemetry.py:115-117,151` at harbor 19f72aa). With
+unreleased or EAP model strings that is a leak. Job results themselves never
+leave the machine: `harbor run` only writes the local `jobs/` directory, and
+Hub sharing is a separate explicit command.
+
 ```bash
+export HARBOR_TELEMETRY=0
+
 # Red-path proof, no tokens: nop agent leaves the fixture unmodified.
 harbor run -y -p harbor/tasks/agent-021-avoid-fetch-in-effect -a nop --job-name nop-021
 

--- a/harbor/sync-tasks.sh
+++ b/harbor/sync-tasks.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Materialize harbor/tasks/ from the synced evals/ directory (which itself
+# comes from vercel/next.js via `pnpm sync-evals`). Both evals/ and
+# harbor/tasks/ are generated and gitignored; templates + this script are the
+# committed artifact.
+#
+#   pnpm sync-evals && ./harbor/sync-tasks.sh
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+if [ ! -d evals ]; then
+  echo "evals/ not found — run \`pnpm sync-evals\` first" >&2
+  exit 1
+fi
+
+# The judge helper and the claude-code runner ship into every task's tests/
+# so eval-helper.mjs's hard-coded __agent_eval__/ paths resolve in-container.
+pkg=$(ls -d node_modules/.pnpm/@vercel+agent-eval@*/node_modules/@vercel/agent-eval | head -1)
+helper="$pkg/dist/lib/agents/eval-helper.mjs"
+runner="$pkg/dist/lib/agents/claude-code/run.mjs"
+[ -f "$helper" ] || { echo "eval-helper.mjs not found — run \`pnpm install\` first" >&2; exit 1; }
+
+rm -rf harbor/tasks
+count=0
+for src in evals/agent-*/; do
+  eval_name=$(basename "$src")
+  dst="harbor/tasks/$eval_name"
+
+  mkdir -p "$dst/environment/workspace" "$dst/tests"
+
+  cp harbor/templates/task.toml "$dst/task.toml"
+  cp "$src/PROMPT.md" "$dst/instruction.md"
+  cp harbor/templates/Dockerfile "$dst/environment/Dockerfile"
+  cp harbor/templates/test.sh "$dst/tests/test.sh"
+  cp harbor/templates/report-reward.mjs "$dst/tests/report-reward.mjs"
+  cp "$src/EVAL.ts" "$dst/tests/EVAL.ts"
+  cp "$helper" "$dst/tests/eval-helper.mjs"
+  cp "$runner" "$dst/tests/run.mjs"
+
+  # Fixture = the eval minus the files agent-eval withholds (TEST_FILE_PATTERNS)
+  # and local artifacts.
+  (cd "$src" && tar cf - --exclude PROMPT.md --exclude EVAL.ts \
+    --exclude node_modules --exclude .next --exclude next-env.d.ts \
+    --exclude package-lock.json .) |
+    tar xf - -C "$dst/environment/workspace"
+
+  chmod +x "$dst/tests/test.sh"
+  count=$((count + 1))
+done
+
+echo "synced $count tasks into harbor/tasks/"

--- a/harbor/templates/Dockerfile
+++ b/harbor/templates/Dockerfile
@@ -1,0 +1,12 @@
+# Shared environment image for every eval. sync-tasks.sh copies the eval's
+# fixture next to this file under workspace/ before the build.
+FROM node:22-bookworm
+
+WORKDIR /app
+COPY workspace/ /app/
+# Parity with @vercel/agent-eval: project deps are installed before the agent
+# starts, then Next.js is bumped to the latest canary (the setup step every
+# experiment in experiments/ runs). The canary version is whatever is current
+# at image-build time; rebuild with --no-cache to re-pin.
+RUN npm install
+RUN npm install next@canary

--- a/harbor/templates/report-reward.mjs
+++ b/harbor/templates/report-reward.mjs
@@ -1,0 +1,14 @@
+// Map the two validation exits (vitest EVAL.ts, npm run build) to harbor's
+// reward.json. Mirrors agent-eval's allPassed = test && every(script).
+const [, , vitestExit, buildExit] = process.argv;
+
+const vitestPassed = Number(vitestExit) === 0 ? 1 : 0;
+const buildPassed = Number(buildExit) === 0 ? 1 : 0;
+
+console.log(
+  JSON.stringify({
+    reward: vitestPassed && buildPassed ? 1 : 0,
+    vitestPassed,
+    buildPassed,
+  }),
+);

--- a/harbor/templates/task.toml
+++ b/harbor/templates/task.toml
@@ -1,0 +1,26 @@
+version = "1.0"
+
+[metadata]
+author_name = "Jude Gao"
+category = "web-development"
+tags = ["next-evals-oss"]
+
+[agent]
+# Matches `timeout: 720` in experiments/*.ts.
+timeout_sec = 720.0
+
+[verifier]
+timeout_sec = 900.0
+
+[verifier.env]
+# The LLM-judge evals (toSatisfyCriterion in EVAL.ts) re-invoke the claude CLI
+# at grading time; forward the gateway credentials from the host. Empty
+# defaults keep credential-free runs working — test.sh unsets empty values.
+ANTHROPIC_BASE_URL = "${ANTHROPIC_BASE_URL:-}"
+ANTHROPIC_AUTH_TOKEN = "${ANTHROPIC_AUTH_TOKEN:-}"
+ANTHROPIC_MODEL = "${ANTHROPIC_MODEL:-}"
+
+[environment]
+build_timeout_sec = 1800.0
+cpus = 2
+memory_mb = 4096

--- a/harbor/templates/test.sh
+++ b/harbor/templates/test.sh
@@ -12,6 +12,10 @@ set -uo pipefail
 
 # The LLM-judge matcher re-invokes the claude CLI installed for the agent run.
 export PATH="$HOME/.local/bin:$PATH"
+# Harbor containers run the verifier as root; Claude Code refuses
+# --dangerously-skip-permissions as root unless IS_SANDBOX=1 (harbor's agent
+# phase sets the same flag).
+export IS_SANDBOX=1
 
 # task.toml [verifier.env] forwards ANTHROPIC_* with empty-string defaults so
 # non-judge runs work without credentials; drop the empties so the claude CLI

--- a/harbor/templates/test.sh
+++ b/harbor/templates/test.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Verifier — replicates @vercel/agent-eval's validation phase 1:1:
+#   1. materialize __agent_eval__/ (judge helper + agent runner, the paths
+#      eval-helper.mjs hard-codes),
+#   2. copy the withheld EVAL.ts into the workspace,
+#   3. write the same vitest.config.ts the harness generates (helper as
+#      setupFiles so `toSatisfyCriterion` is registered, aliased as
+#      @vercel/agent-eval/eval),
+#   4. `npx vitest run` then `npm run build` (experiments use scripts:
+#      ['build']) — reward 1 iff both exit 0.
+set -uo pipefail
+
+# The LLM-judge matcher re-invokes the claude CLI installed for the agent run.
+export PATH="$HOME/.local/bin:$PATH"
+
+# task.toml [verifier.env] forwards ANTHROPIC_* with empty-string defaults so
+# non-judge runs work without credentials; drop the empties so the claude CLI
+# never sees a set-but-empty variable.
+for v in ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN ANTHROPIC_API_KEY ANTHROPIC_MODEL; do
+  [ -z "${!v:-}" ] && unset "$v"
+done
+
+cd /app
+
+mkdir -p /app/__agent_eval__
+cp /tests/eval-helper.mjs /app/__agent_eval__/eval-helper.mjs
+cp /tests/run.mjs /app/__agent_eval__/run.mjs
+cp /tests/EVAL.ts /app/EVAL.ts
+
+cat > /app/vitest.config.ts <<'EOF'
+import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: {
+    include: ['EVAL.ts'],
+    globals: false,
+    testTimeout: 900000,
+    hookTimeout: 900000,
+    setupFiles: ['/app/__agent_eval__/eval-helper.mjs'],
+  },
+  resolve: {
+    alias: { '@vercel/agent-eval/eval': '/app/__agent_eval__/eval-helper.mjs' },
+  },
+});
+EOF
+
+npx vitest run 2>&1 | tee /logs/verifier/vitest-output.txt
+vitest_exit=${PIPESTATUS[0]}
+
+npm run build 2>&1 | tee /logs/verifier/build-output.txt
+build_exit=${PIPESTATUS[0]}
+
+node /tests/report-reward.mjs "$vitest_exit" "$build_exit" > /logs/verifier/reward.json
+echo "reward.json:"
+cat /logs/verifier/reward.json


### PR DESCRIPTION
Runs the same evals on Harbor, the terminal-bench harness, instead of `@vercel/agent-eval`, as a spike. Both `evals/` and `harbor/tasks/` stay generated: `pnpm sync-evals` pulls fixtures from vercel/next.js as before, and `harbor/sync-tasks.sh` converts them into 24 Harbor tasks. `tests/test.sh` replicates the validation phase (writes the same `vitest.config.ts` the harness generates, runs `npx vitest run EVAL.ts`, then `npm run build` per `scripts: ['build']`), and the experiments' `next@canary` setup step moves into the task Dockerfile. The three LLM-judge evals work by vendoring `eval-helper.mjs` and the claude-code `run.mjs` into `tests/` and staging them at the hardcoded `__agent_eval__/` paths, with gateway credentials forwarded through `[verifier.env]`.

Proven on local Docker (harbor 0.19.0):

| job           | agent                          | reward | vitestPassed | buildPassed | cost  |
|---------------|--------------------------------|--------|--------------|-------------|-------|
| nop-021       | nop (red path)                 | 0      | 0            | 1           | $0    |
| claude-021    | claude-code, claude-sonnet-4-6 | 1      | 1            | 1           | $0.23 |
| claude-034-v2 | claude-code, claude-sonnet-4-6 | 1      | 1            | 1           | $0.08 |

claude-034 is a judge eval; the judged test took 19.7s (the in-container claude invocation) vs 236ms when the judge could not launch. One real difference surfaced: harbor runs the verifier as root and Claude Code refuses `--dangerously-skip-permissions` as root, so `test.sh` sets `IS_SANDBOX=1`, the same flag harbor's agent phase sets. Not ported: the `--agents-md` arm, `earlyExit` semantics, and the `export-results.ts` publishing pipeline (details in `harbor/README.md`).
