### PR TITLE
fix: shell command built from environment values

### DIFF
--- a/scripts/sync-evals.ts
+++ b/scripts/sync-evals.ts
@@ -12,7 +12,7 @@
  */
 
 import { execSync } from 'node:child_process';
-import { existsSync, rmSync } from 'node:fs';
+import { cpSync, existsSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 
 const REPO_URL = 'https://github.com/vercel/next.js.git';
@@ -42,7 +42,7 @@ async function main(): Promise<void> {
   execSync(`git -C "${repoDir}" checkout -q FETCH_HEAD`, { stdio: 'inherit' });
 
   // Copy evals into place
-  execSync(`cp -r "${tmpDir}/next.js/evals/evals" "${evalsDir}"`);
+  cpSync(join(tmpDir, 'next.js', 'evals', 'evals'), evalsDir, { recursive: true });
   rmSync(tmpDir, { recursive: true, force: true });
 
   // Carry config-only changes forward in cached results (the framework owns this now;


### PR DESCRIPTION
Dynamically constructing a shell command with values from the local environment, such as file paths, may inadvertently change the meaning of the shell command. Such changes can occur when an environment value contains characters that the shell interprets in a special way, for instance quotes and spaces. This can result in the shell command misbehaving, or even allowing a malicious user to execute arbitrary commands on the system.



fix is to remove shell interpretation entirely for the copy step and use Node’s filesystem API to copy directories directly.  In `scripts/sync-evals.ts`, replace the `cp -r ...` `execSync` call (line 45 region) with `cpSync` from `node:fs`. This keeps behavior (recursive directory copy) while eliminating shell command construction from environment-derived paths.

Concretely:
- Update the existing `node:fs` import to include `cpSync`.
- Replace:
  - `execSync(\`cp -r "${tmpDir}/next.js/evals/evals" "${evalsDir}"\`);`
- With:
  - `cpSync(join(tmpDir, 'next.js', 'evals', 'evals'), evalsDir, { recursive: true });`