### PR TITLE
Bump @vercel/agent-eval to 1.5.1 (credential redaction)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "typescript": "^5.6.0"
   },
   "dependencies": {
-    "@vercel/agent-eval": "^1.3.0"
+    "@vercel/agent-eval": "^1.5.1"
   },
   "packageManager": "pnpm@10.29.2+sha512.bef43fa759d91fd2da4b319a5a0d13ef7a45bb985a3d7342058470f9d2051a3ba8674e629672654686ef9443ad13a82da2beb9eeb3e0221c87b8154fff9d74b8"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@vercel/agent-eval':
-        specifier: ^1.3.0
-        version: 1.3.0
+        specifier: ^1.5.1
+        version: 1.5.1
     devDependencies:
       tsx:
         specifier: ^4.19.0
@@ -273,8 +273,8 @@ packages:
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
-  '@vercel/agent-eval@1.3.0':
-    resolution: {integrity: sha512-x8mxdvteWp7z4I5VuOm2mknlyMUTevbbp7RCiPg7gsVSknOcVxzJxBCaccenHoux2JKwK63svnzfoeIfB2dDWg==}
+  '@vercel/agent-eval@1.5.1':
+    resolution: {integrity: sha512-rqOQtgJ8IjRkFkbB+onoc7hDr7PrZQMPz+yi/glN0gXYdqL1l5nkkAXGDQIYOzWR9c6Qx+b7lwohb+e93xxcHw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -951,7 +951,7 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
-  '@vercel/agent-eval@1.3.0':
+  '@vercel/agent-eval@1.5.1':
     dependencies:
       '@ai-sdk/anthropic': 1.2.12(zod@3.25.76)
       '@vercel/sandbox': 1.8.1


### PR DESCRIPTION
Picks up the credential redaction from [vercel-labs/agent-eval#186](https://github.com/vercel-labs/agent-eval/pull/186), published as 1.5.1. That is the actual fix for the leak that #108 cleaned up after — until this lands, a **new** opencode run still writes the AI Gateway credential into its transcript, because the framework puts it in the sandbox's `opencode.json` and models read that file while orienting.

This closes the loop: #108 removed the 287 already-committed occurrences, and this stops new ones.

## Verified against the published artifact

Not a local build — the actual tarball resolved into `node_modules`. I fed it the real pre-scrub transcript from `88ec653a`, plus the credential planted in every other text-bearing field of an `AgentRunResult`:

| check | |
|---|---|
| token absent from transcript, output, error, test output, script output, generated file | ✅ |
| token absent from the **entire serialized result** | ✅ |
| no `eyJhbGciOi` prefix anywhere | ✅ |
| transcript still parses as JSONL | ✅ |
| non-text fields (duration, observedModel) intact | ✅ |
| redacted transcript byte-identical to what #108 committed | ✅ |

## ⚠️ This is not a pure security patch

It moves off the pinned 1.3.0 through two minors, and two of those changes touch run behavior:

- **1.3.1** — OpenCode explicit model overrides now resolve host-side. This decides which model actually runs for the opencode experiments in this repo (`grok-*`, `glm-*`, `kimi-*`, `minimax-*`).
- **1.4.0** — Codex shell-tool canary and repair for native-default runs, plus a new `modelRepair` field propagated into persisted results. Also adds the `toContainText` EVAL.ts matcher.
- **1.5.0** — Custom `Agent` registration under arbitrary string IDs.

Hence its own PR rather than bundled with the scrub.

## What I checked, and what I did not

Ran the CI sequence locally — `pnpm sync-evals` at the pinned SHA then `check-stale.mjs` — and the gate passes, so the bump does not push any (experiment, eval) pair into unaccepted staleness. Cost unit tests pass 8/8.

I did **not** re-run any evals. If 1.3.1's model resolution or 1.4.0's codex repair changes behavior, it will surface on the next run rather than in this diff. Worth keeping an eye on `modelRepair` appearing in codex results, and on observed models for the opencode experiments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
