### PR TITLE
Make a fresh clone runnable: bootstrap, preflight, and honest setup docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,59 @@
+# Copy to .env.local and fill in only what you need:
+#
+#   cp .env.example .env.local
+#
+# The runner loads .env.local first, then .env — both with override, so a value
+# in either file WINS over the same variable already exported in your shell.
+# Run `pnpm preflight` to see which of these are resolved and which are missing.
+
+
+# ── Sandbox: pick ONE of the two paths ────────────────────────────────────────
+# Every experiment sets `sandbox: "vercel"`, so evals run in a Vercel Sandbox
+# and one of these paths must resolve.
+
+# Path A — OIDC. Easiest locally; `vercel env pull` writes the token here.
+#   npx vercel link && npx vercel env pull .env.local
+# The token is short-lived: re-pull when it expires. It also authenticates the
+# AI Gateway, so on this path you can leave the agent keys below unset.
+# VERCEL_OIDC_TOKEN=
+
+# Path B — a long-lived access token. ALL THREE are required together. Setting
+# only one or two is worse than setting none: the runner silently falls back to
+# Path A and fails with a confusing "Could not get credentials from OIDC
+# context" error. `pnpm preflight` flags that case.
+# VERCEL_TOKEN=
+# VERCEL_TEAM_ID=
+# VERCEL_PROJECT_ID=
+
+
+# ── Agent credentials: whichever agents you actually run ──────────────────────
+# Each experiment names an `agent`, and the agent decides which key it reads.
+# VERCEL_OIDC_TOKEN is the fallback for every one of them.
+# `pnpm preflight <experiment>` prints the exact variable a given experiment wants.
+
+# agent: 'vercel-ai-gateway/*' — most experiments.
+# Create a key at https://vercel.com/dashboard -> AI Gateway.
+# AI_GATEWAY_API_KEY=
+
+# agent: 'claude-code' — direct Anthropic API.
+# ANTHROPIC_API_KEY=
+# A Claude subscription token works instead of the API key, and takes
+# precedence over ANTHROPIC_API_KEY whenever it is set.
+# CLAUDE_CODE_OAUTH_TOKEN=
+
+# agent: 'codex' — direct OpenAI API.
+# OPENAI_API_KEY=
+
+# agent: 'gemini'
+# GEMINI_API_KEY=
+
+# agent: 'cursor'
+# CURSOR_API_KEY=
+
+
+# ── Optional ──────────────────────────────────────────────────────────────────
+# Narrows which evals an experiment runs — an eval name, a glob, or a
+# comma-separated list. Honoured only by experiments whose config reads it
+# (`evals: process.env.EVAL_FILTER ?? '*'`); the rest always run every eval.
+# Handy for keeping a first run cheap while you verify credentials.
+# EVAL_FILTER=agent-025-prefer-next-link

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ dist/
 /evals/
 .sync-tmp/
 .env*
+# ...but the checked-in template that documents them is not a secret.
+!.env.example

--- a/README.md
+++ b/README.md
@@ -2,49 +2,137 @@
 
 Agent evaluations for Next.js coding tasks, powered by [`@vercel/agent-eval`](https://www.npmjs.com/package/@vercel/agent-eval).
 
-## Setup
+Each eval hands a coding agent a small Next.js app and a prompt, lets it work in an
+isolated sandbox, then runs withheld assertions against what it produced.
+
+## Quick start
 
 ```bash
-npm install
-cp .env.local .env   # requires VERCEL_OIDC_TOKEN and AI_GATEWAY_API_KEY
+pnpm bootstrap                 # install, sync eval fixtures, check credentials
+cp .env.example .env.local     # then fill in the credentials it asked for
+pnpm preflight                 # confirm they resolve
+pnpm eval:smoke claude-opus-5  # one eval, one run, real sandbox
 ```
+
+`pnpm bootstrap` is not required — it just runs the three setup steps below in
+order, because the middle one is easy to miss.
+
+## Setup
+
+### 1. Install
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+pnpm only: the lockfile and `packageManager` pin are pnpm, and CI installs frozen.
+
+### 2. Sync the eval fixtures — required
+
+```bash
+pnpm sync-evals          # from vercel/next.js@canary
+pnpm sync-evals <ref>    # ...or a branch, tag, or commit SHA
+```
+
+**The evals are not in this repo.** They live in
+[`vercel/next.js`](https://github.com/vercel/next.js/tree/canary/evals/evals) and
+`evals/` is git-ignored here, so a fresh clone has no fixtures and every command
+fails with `Evals directory not found`. `sync-evals` sparse-checkouts them.
+
+Syncing from `canary` picks up whatever landed upstream since results were last
+recorded, so it usually reports evals as changed:
+
+```
+N result(s) have a changed eval and were left stale — run them to refresh.
+```
+
+That is expected, not a problem — it is the incremental workflow telling you what
+`pnpm status` will now list as work. To match CI instead, pass the SHA that
+[`.github/workflows/eval-cache-check.yml`](.github/workflows/eval-cache-check.yml)
+pins.
+
+### 3. Provide credentials
+
+Copy [`.env.example`](.env.example) to `.env.local` and fill in what you need.
+`pnpm preflight` reports exactly which variables are missing, and for which
+experiments — run it instead of guessing.
+
+**Sandbox.** Every experiment sets `sandbox: "vercel"`, so runs need Vercel
+Sandbox credentials by one of two paths:
+
+| Path | Variables | Notes |
+|------|-----------|-------|
+| OIDC | `VERCEL_OIDC_TOKEN` | `npx vercel link && npx vercel env pull .env.local`. Short-lived — re-pull when it expires. Also authenticates the AI Gateway. |
+| Access token | `VERCEL_TOKEN` **and** `VERCEL_TEAM_ID` **and** `VERCEL_PROJECT_ID` | All three or none. |
+
+A partial token triple is the real trap here: `@vercel/sandbox` only treats the
+three as credentials when all three are set, so one or two silently falls back to
+the OIDC path and fails with `Could not get credentials from OIDC context` — which
+names neither the variable you forgot nor the path you meant. `pnpm preflight`
+calls this out.
+
+**Agents.** Each experiment names an `agent`, and the agent decides which key it
+reads. `VERCEL_OIDC_TOKEN` is the fallback for all of them, so the OIDC path above
+can cover this whole table on its own.
+
+| Agent | Key |
+|-------|-----|
+| `vercel-ai-gateway/*` (most experiments) | `AI_GATEWAY_API_KEY` |
+| `claude-code` | `CLAUDE_CODE_OAUTH_TOKEN` if set, else `ANTHROPIC_API_KEY` |
+| `codex` | `OPENAI_API_KEY` |
+| `gemini` | `GEMINI_API_KEY` |
+| `cursor` | `CURSOR_API_KEY` |
+
+Missing an agent's key is not fatal: the runner prints `… not set, skipping
+<experiment>` and moves on. That line is easy to lose in a long run, so
+`pnpm preflight <experiment>` fails outright when you name an experiment you
+cannot actually run.
 
 ## Scripts
 
-### `npm run eval`
+| Script | What it does |
+|--------|--------------|
+| `pnpm bootstrap [ref]` | Install, sync fixtures, run preflight. |
+| `pnpm preflight [experiment...]` | Check toolchain, fixtures, sandbox auth, and agent keys. Read-only. Names or globs narrow it; naming an experiment makes a missing key an error rather than a warning. |
+| `pnpm status [experiment...]` | What is new or changed, per experiment, and the work that implies. Read-only. |
+| `pnpm eval:dry <experiment>` | Print the plan — evals, runs, model, sandbox backend — without executing. |
+| `pnpm eval:smoke <experiment...>` | One eval, one run each. The cheapest thing that proves credentials and sandbox actually work. |
+| `pnpm eval:run <experiment...>` | Run the new/changed evals for those experiments. |
+| `pnpm eval` | Interactive: show status, then pick. |
+| `pnpm playground` | Web UI for browsing results in `results/`. |
+| `pnpm sync-evals [ref]` | Re-sync fixtures from `vercel/next.js`. |
+| `pnpm export-results` | Write `agent-results.json` for nextjs.org/evals. |
+| `pnpm typecheck` | `tsc --noEmit` over `experiments/`. |
+| `pnpm test:cost` | Unit tests for token extraction and pricing in `scripts/cost.ts`. |
 
-Runs agent evaluations with memoization. Only runs (model, eval) pairs that haven't been completed yet.
+Anything that runs an eval takes experiment names or globs — `pnpm eval:run
+'claude-*'`. Some experiments also honour `EVAL_FILTER` (an eval name, a glob, or a
+comma-separated list) to narrow which evals run; that is per-config, so check the
+experiment before relying on it.
 
-```bash
-npm run eval              # Run only missing pairs
-npm run eval:dry          # Preview what would run
-npm run eval -- --force   # Re-run everything
-npm run eval:smoke        # Run 1 eval per experiment (sanity check)
-```
+Results are memoized by a fingerprint of the eval content plus the experiment
+config, so a re-run only covers what actually changed. `--force` ignores the cache.
 
-The runner automatically detects:
-- **New model added** → runs all evals for that model
-- **New eval added** → runs that eval for all models
-- **Already completed** → skips
+### `pnpm export-results`
 
-### `npm run export-results`
+Exports clean results to `agent-results.json`. Non-model failures (infra/timeout)
+are automatically deleted during eval runs, so only valid model results are
+exported.
 
-Exports clean results to `agent-results.json`. Non-model failures (infra/timeout) are automatically deleted during eval runs, so only valid model results are exported.
-
-Each experiment also gets an `avgCostUsd`: the mean list cost per eval. Tokens are read from each run's `transcript-raw.jsonl` (handled per harness in `scripts/cost.ts`) and multiplied by the list prices in `MODEL_PRICING`. A model with no price entry, or whose runs carry no token usage, exports `null` and renders as N/A. Prices are a snapshot, so re-run the export to refresh them.
-
-### `npm run test:cost`
-
-Unit tests for the token extraction and pricing in `scripts/cost.ts`.
+Each experiment also gets an `avgCostUsd`: the mean list cost per eval. Tokens are
+read from each run's `transcript-raw.jsonl` (handled per harness in
+`scripts/cost.ts`) and multiplied by the list prices in `MODEL_PRICING`. A model
+with no price entry, or whose runs carry no token usage, exports `null` and renders
+as N/A. Prices are a snapshot, so re-run the export to refresh them.
 
 ## Eval structure
 
-Each eval is a self-contained Next.js project in `evals/`:
+Each eval is a self-contained Next.js project:
 
 ```
 evals/agent-031-proxy-middleware/
 ├── PROMPT.md        # task given to the agent
-├── EVAL.ts          # vitest assertions (withheld from the agent)
+├── EVAL.ts          # assertions (withheld from the agent)
 ├── package.json     # Next.js project manifest
 ├── tsconfig.json
 ├── next.config.ts
@@ -62,25 +150,41 @@ evals/agent-031-proxy-middleware/
 
 ## Adding a new eval
 
-1. Create a directory under `evals/` (e.g., `evals/agent-040-my-eval/`)
-2. Add `PROMPT.md` with the task description
-3. Add `EVAL.ts` with vitest assertions
-4. Add `package.json` with `"type": "module"` and `"build": "next build"`
-5. Add the Next.js source files the agent starts with
-6. Run `npm run eval` — it will automatically run the new eval for all models
+Evals are authored in
+[`vercel/next.js`](https://github.com/vercel/next.js/tree/canary/evals/evals), not
+here — `evals/` in this repo is a synced copy and is git-ignored, so anything you
+add to it locally is overwritten by the next `pnpm sync-evals`.
+
+1. Add the eval upstream, under `evals/evals/` in `vercel/next.js`.
+2. Here: `pnpm sync-evals` to pull it in.
+3. `pnpm status` — it shows up as `new` for every experiment.
+4. `pnpm eval:run <experiment>` to record results.
 
 ## Adding a new model
 
 1. Create a config in `experiments/` (e.g., `experiments/gpt-5.ts`)
 2. Add the display name to `MODEL_NAMES` in `scripts/export-results.ts`
 3. Add the list price to `MODEL_PRICING` in `scripts/cost.ts` (or the cost column shows N/A)
-4. Run `npm run eval` — it will automatically run all evals for the new model
+4. `pnpm eval:run <experiment>` — every eval is new for it
+
+Editing an existing experiment config changes its fingerprint, which makes its
+cached results stale. That is the intended signal, but it means config churn costs
+real re-runs.
+
+## CI
+
+[`eval-cache-check.yml`](.github/workflows/eval-cache-check.yml) syncs fixtures at
+a pinned `vercel/next.js` SHA and runs `scripts/check-stale.mjs`, which fails on any
+new or changed eval that is not listed in that script's `ACCEPTED_STALE`. CI never
+runs an eval — it only checks that the cache is fresh or explicitly accepted as
+stale. To adopt upstream changes: bump the SHA, re-run the experiments you are
+refreshing, and record the rest in `ACCEPTED_STALE`.
 
 ## Publishing to nextjs.org/evals
 
 After running evals:
 
-1. Export results: `npm run export-results`
+1. Export results: `pnpm export-results`
 2. Copy to front repo:
    ```bash
    cp agent-results.json <path-to-front>/apps/next-site/app/\(next-site\)/evals/agent-results.json
@@ -88,6 +192,9 @@ After running evals:
 3. Commit and deploy the front repo
 
 ## Current evals
+
+As synced from `vercel/next.js@canary`. Upstream is the source of truth — after a
+sync, `ls evals/` is authoritative.
 
 | Eval | Tests |
 |------|-------|
@@ -111,6 +218,10 @@ After running evals:
 | agent-037 | updateTag() for read-your-own-writes |
 | agent-038 | Refresh page via revalidatePath |
 | agent-039 | Indirect proxy (request logging) |
+| agent-040 | Instant navigation |
+| agent-041 | Optimize the PPR shell |
+| agent-042 | Enable PPR |
+| agent-043 | View transitions with shared elements |
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -3,12 +3,23 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "bootstrap": "node scripts/bootstrap.mjs",
+    "preflight": "node scripts/preflight.mjs",
     "eval": "agent-eval",
+    "eval:dry": "agent-eval --dry",
+    "eval:smoke": "agent-eval run --smoke",
+    "eval:run": "agent-eval run",
+    "status": "agent-eval status",
+    "playground": "agent-eval playground",
+    "typecheck": "tsc --noEmit",
     "sync-evals": "tsx scripts/sync-evals.ts",
     "export-results": "tsx scripts/export-results.ts",
     "test:cost": "tsx --test scripts/cost.test.ts"
   },
   "devDependencies": {
+    "@types/node": "^22.10.0",
+    "dotenv": "^16.4.5",
+    "minimatch": "^10.2.4",
     "tsx": "^4.19.0",
     "typescript": "^5.6.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,15 @@ importers:
         specifier: ^1.5.1
         version: 1.5.1
     devDependencies:
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.20.1
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.6.1
+      minimatch:
+        specifier: ^10.2.4
+        version: 10.2.4
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
@@ -270,8 +279,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@types/node@25.5.0':
-    resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
 
   '@vercel/agent-eval@1.5.1':
     resolution: {integrity: sha512-rqOQtgJ8IjRkFkbB+onoc7hDr7PrZQMPz+yi/glN0gXYdqL1l5nkkAXGDQIYOzWR9c6Qx+b7lwohb+e93xxcHw==}
@@ -719,8 +728,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@7.18.2:
-    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   undici@7.24.4:
     resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
@@ -947,9 +956,9 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@types/node@25.5.0':
+  '@types/node@22.20.1':
     dependencies:
-      undici-types: 7.18.2
+      undici-types: 6.21.0
 
   '@vercel/agent-eval@1.5.1':
     dependencies:
@@ -1312,7 +1321,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 25.5.0
+      '@types/node': 22.20.1
       long: 5.3.2
 
   pump@3.0.4:
@@ -1458,7 +1467,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  undici-types@7.18.2: {}
+  undici-types@6.21.0: {}
 
   undici@7.24.4: {}
 

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -1,0 +1,78 @@
+/**
+ * Fresh clone -> ready to run an eval, in one command.
+ *
+ * The manual sequence is only three steps, but the middle one is easy to miss:
+ * `evals/` is git-ignored and synced from vercel/next.js, so a clone that looks
+ * complete has no fixtures at all and every command dies in the framework's
+ * loader. This runs install -> sync -> preflight in order and ends by printing
+ * what to do next.
+ *
+ * Named `bootstrap`, not `setup`, because `pnpm setup` is a built-in pnpm
+ * command and would shadow the script.
+ *
+ * Usage:
+ *   pnpm bootstrap           # sync fixtures from next.js canary
+ *   pnpm bootstrap <ref>     # ...from a branch, tag, or commit SHA
+ *
+ * Pass the SHA that .github/workflows/eval-cache-check.yml pins to reproduce
+ * CI's view of the fixtures; canary drifts, and drift shows up as stale evals.
+ */
+import { spawnSync } from 'node:child_process';
+
+const ref = process.argv[2];
+
+// Reject a flag-shaped ref before the install, not three minutes into it. The
+// only argument this takes is a git ref, so anything starting with `-` is a
+// typo or a flag meant for something else.
+if (ref?.startsWith('-')) {
+  console.error(`✗ "${ref}" is not a ref. Usage: pnpm bootstrap [branch|tag|sha]`);
+  process.exit(2);
+}
+
+// Raw escapes rather than a color library, so this stays dependency-light — but
+// that means honouring NO_COLOR and piped output by hand.
+const color = process.stdout.isTTY && !process.env.NO_COLOR;
+const paint = (code, s) => (color ? `\x1b[${code}m${s}\x1b[0m` : s);
+
+const step = (n, total, label) => console.log(`\n${paint(1, `[${n}/${total}] ${label}`)}`);
+
+/** Run a step, inheriting stdio. Returns the exit code. */
+function run(cmd, args) {
+  console.log(paint(90, `$ ${cmd} ${args.join(' ')}`));
+  return spawnSync(cmd, args, { stdio: 'inherit' }).status ?? 1;
+}
+
+/** Run a step that must succeed for the following ones to mean anything. */
+function runOrExit(cmd, args) {
+  const code = run(cmd, args);
+  if (code !== 0) {
+    console.error(`\n${paint(31, `✗ \`${cmd} ${args.join(' ')}\` failed (exit ${code}).`)}`);
+    process.exit(code);
+  }
+}
+
+step(1, 3, 'Install dependencies');
+runOrExit('pnpm', ['install', '--frozen-lockfile']);
+
+step(2, 3, `Sync eval fixtures from vercel/next.js@${ref ?? 'canary'}`);
+runOrExit('pnpm', ['sync-evals', ...(ref ? [ref] : [])]);
+
+// Preflight has already printed the specifics and the fix for each problem, so
+// this only needs to route the reader. Its exit code is propagated rather than
+// swallowed: "bootstrap succeeded" should mean you can actually run an eval, so
+// a Dockerfile or CI step that ends here does not report success on a tree that
+// has no usable credentials.
+step(3, 3, 'Check credentials and toolchain');
+const preflightCode = run('node', ['scripts/preflight.mjs']);
+
+console.log(`\n${paint(1, 'Next')}`);
+if (preflightCode !== 0) {
+  console.log('  Installed and synced, but the checks above are unresolved.');
+  console.log('  Fill in .env.local — see .env.example — then re-check: pnpm preflight');
+  process.exit(preflightCode);
+}
+
+console.log('  pnpm status                       what is new or changed, per experiment');
+console.log('  pnpm eval:dry <experiment>        preview a run without executing it');
+console.log('  pnpm eval:smoke <experiment>      one eval, one run, real sandbox');
+console.log('  pnpm eval:run <experiment>        the real thing');

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -1,0 +1,329 @@
+/**
+ * Preflight for "can this machine actually run an eval?".
+ *
+ * The first two checks below came out of standing this repo up in a fresh
+ * sandbox, and both surface late and cryptically if you just run the eval: a
+ * missing `evals/` dies inside the framework's fixture loader, and a half-filled
+ * VERCEL_TOKEN triple silently degrades to the OIDC path and reports "Could not
+ * get credentials from OIDC context". A missing agent key is quieter still — the
+ * runner prints one "skipping <experiment>" line and carries on.
+ *
+ * The checks are read-only and ask the framework the same questions the runner
+ * asks — `loadConfig` for each experiment, then the agent's own
+ * `getApiKeyEnvVar()` — rather than pattern-matching the configs, so this can't
+ * drift from what `agent-eval` will really do.
+ *
+ * Usage:
+ *   pnpm preflight                  # every experiment; missing agent keys warn
+ *   pnpm preflight claude-opus-5    # named experiments; missing agent keys fail
+ *   pnpm preflight 'claude-*'       # globs work too
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync, readdirSync } from 'node:fs';
+import { basename, resolve } from 'node:path';
+
+import { getAgent, loadConfig, resolveBackend } from '@vercel/agent-eval';
+import { config as dotenvConfig } from 'dotenv';
+import { minimatch } from 'minimatch';
+
+// Mirror the CLI's own env loading (cli.js), so preflight sees exactly the
+// environment the runner will: .env.local first, then .env, both overriding
+// what is already exported in the shell.
+dotenvConfig({ path: '.env.local', override: true });
+dotenvConfig({ override: true });
+
+/** Hard floor: @vercel/agent-eval declares engines.node >= 18. */
+const MIN_NODE_MAJOR = 18;
+/** Soft floor: what .github/workflows/eval-cache-check.yml actually runs. */
+const CI_NODE_MAJOR = 22;
+
+// Raw escapes rather than a color library, so this stays dependency-light — but
+// that means honouring NO_COLOR and piped output by hand, or CI logs fill with
+// escape codes.
+const color = process.stdout.isTTY && !process.env.NO_COLOR;
+const paint = (code, s) => (color ? `\x1b[${code}m${s}\x1b[0m` : s);
+
+const ok = (s) => `${paint(32, '✓')} ${s}`;
+const bad = (s) => `${paint(31, '✗')} ${s}`;
+const warn = (s) => `${paint(33, '!')} ${s}`;
+const dim = (s) => paint(90, s);
+const heading = (s) => `\n${paint(1, s)}`;
+
+/** Problems that mean "you cannot run evals at all". */
+const errors = [];
+/** Problems that only narrow what you can run. */
+const warnings = [];
+
+function fail(msg, hint) {
+  errors.push({ msg, hint });
+  console.log(bad(msg));
+  if (hint) console.log(dim(`    ${hint}`));
+}
+
+function caution(msg, hint) {
+  warnings.push({ msg, hint });
+  console.log(warn(msg));
+  if (hint) console.log(dim(`    ${hint}`));
+}
+
+function pass(msg, detail) {
+  console.log(ok(msg) + (detail ? ` ${dim(detail)}` : ''));
+}
+
+/** Present AND non-empty — an exported-but-blank var is not a credential. */
+const has = (name) => Boolean(process.env[name]);
+
+function list(names, max = 4) {
+  const shown = names.slice(0, max).join(', ');
+  return names.length > max ? `${shown}, +${names.length - max} more` : shown;
+}
+
+// Toolchain
+
+function checkToolchain() {
+  console.log(heading('Toolchain'));
+
+  const major = Number(process.versions.node.split('.')[0]);
+  if (major >= CI_NODE_MAJOR) {
+    pass(`node ${process.version}`);
+  } else if (major >= MIN_NODE_MAJOR) {
+    caution(
+      `node ${process.version}`,
+      `Above @vercel/agent-eval's floor (>= ${MIN_NODE_MAJOR}) but below the ${CI_NODE_MAJOR} CI runs — untested here.`
+    );
+  } else {
+    fail(
+      `node ${process.version} — @vercel/agent-eval requires >= ${MIN_NODE_MAJOR}`,
+      `CI runs node ${CI_NODE_MAJOR}; match that if you can.`
+    );
+  }
+
+  try {
+    const version = execFileSync('pnpm', ['--version'], { encoding: 'utf-8' }).trim();
+    pass(`pnpm ${version}`);
+  } catch {
+    fail('pnpm not found', 'corepack enable, or npm i -g pnpm — the lockfile and workspace are pnpm-only.');
+  }
+}
+
+// Eval fixtures
+
+function checkFixtures() {
+  console.log(heading('Eval fixtures'));
+
+  const evalsDir = resolve('evals');
+  if (!existsSync(evalsDir)) {
+    fail(
+      'evals/ is missing',
+      'Fixtures live upstream in vercel/next.js and are git-ignored here. Run: pnpm sync-evals'
+    );
+    return;
+  }
+
+  const fixtures = readdirSync(evalsDir, { withFileTypes: true }).filter((e) => e.isDirectory());
+  if (fixtures.length === 0) {
+    fail('evals/ is empty', 'Re-run: pnpm sync-evals');
+    return;
+  }
+  pass(`evals/ — ${fixtures.length} fixture(s)`);
+}
+
+// Experiments
+
+/** Load the named experiments (or all of them) exactly as the runner does. */
+async function loadExperiments(patterns) {
+  const dir = resolve('experiments');
+  if (!existsSync(dir)) {
+    fail('experiments/ is missing', 'Are you running this from the repo root?');
+    return [];
+  }
+
+  const all = readdirSync(dir)
+    .filter((f) => f.endsWith('.ts') && !f.startsWith('_temp_'))
+    .sort();
+
+  const selected =
+    patterns.length === 0
+      ? all
+      : all.filter((f) => {
+          const name = basename(f, '.ts');
+          return patterns.some((p) => (p.includes('*') ? minimatch(name, p) : name === p));
+        });
+
+  if (patterns.length > 0 && selected.length === 0) {
+    fail(
+      `No experiments matched: ${patterns.join(', ')}`,
+      `Available: ${list(all.map((f) => basename(f, '.ts')), 8)}`
+    );
+    return [];
+  }
+
+  const loaded = [];
+  for (const file of selected) {
+    const name = basename(file, '.ts');
+    try {
+      loaded.push({ name, config: await loadConfig(resolve(dir, file)) });
+    } catch (err) {
+      fail(`experiments/${file} failed to load`, err instanceof Error ? err.message : String(err));
+    }
+  }
+  return loaded;
+}
+
+// Sandbox
+
+/**
+ * Vercel Sandbox accepts either the full VERCEL_TOKEN triple or an OIDC token.
+ * A partial triple is the trap: @vercel/sandbox only treats the params as
+ * credentials when all three are present, so 1-or-2 falls through to OIDC and
+ * fails there instead of saying which variable you forgot.
+ */
+function checkVercelSandbox(users) {
+  const TRIPLE = ['VERCEL_TOKEN', 'VERCEL_TEAM_ID', 'VERCEL_PROJECT_ID'];
+  const present = TRIPLE.filter(has);
+  const missing = TRIPLE.filter((n) => !has(n));
+
+  if (present.length === TRIPLE.length) {
+    pass('auth — VERCEL_TOKEN + VERCEL_TEAM_ID + VERCEL_PROJECT_ID');
+    return;
+  }
+  if (has('VERCEL_OIDC_TOKEN')) {
+    if (present.length > 0) {
+      caution(
+        `auth — using VERCEL_OIDC_TOKEN; ${list(present)} ignored (incomplete triple, missing ${list(missing)})`,
+        'Harmless, but set all three or none so it is clear which path is live.'
+      );
+    } else {
+      pass('auth — VERCEL_OIDC_TOKEN');
+    }
+    return;
+  }
+
+  if (present.length > 0) {
+    fail(
+      `auth — incomplete: ${list(present)} set, missing ${list(missing)}`,
+      'All three are required together. A partial set falls back to OIDC and dies with ' +
+        '"Could not get credentials from OIDC context".'
+    );
+  } else {
+    fail(
+      `auth — no Vercel Sandbox credentials (needed by ${users} experiment(s))`,
+      'Either: npx vercel link && npx vercel env pull .env.local   (writes VERCEL_OIDC_TOKEN)\n' +
+        '    or: set VERCEL_TOKEN + VERCEL_TEAM_ID + VERCEL_PROJECT_ID. See .env.example.'
+    );
+  }
+}
+
+function checkDockerSandbox(users) {
+  try {
+    execFileSync('docker', ['info'], { stdio: 'ignore' });
+    pass('docker daemon reachable');
+  } catch {
+    fail(
+      `docker daemon unreachable (needed by ${users} experiment(s))`,
+      'Start Docker, or point those experiments at sandbox: "vercel".'
+    );
+  }
+}
+
+function checkSandboxes(experiments) {
+  const byBackend = new Map();
+  for (const { name, config } of experiments) {
+    const backend = resolveBackend({ backend: config.sandbox });
+    if (!byBackend.has(backend)) byBackend.set(backend, []);
+    byBackend.get(backend).push(name);
+  }
+
+  for (const [backend, users] of byBackend) {
+    console.log(heading(`Sandbox: ${backend} — ${users.length} experiment(s)`));
+    if (backend === 'vercel') checkVercelSandbox(users.length);
+    else checkDockerSandbox(users.length);
+  }
+}
+
+// Agent credentials
+
+/**
+ * Group the experiments by the env var their agent reads, then report each var
+ * once. `strict` is set when the user named experiments explicitly: asking
+ * about an experiment you cannot run should fail, whereas the default sweep
+ * covers five providers at once and nobody holds every key.
+ */
+function checkAgentCredentials(experiments, strict) {
+  console.log(heading('Agent credentials'));
+
+  const byEnvVar = new Map();
+  for (const { name, config } of experiments) {
+    let envVar;
+    try {
+      envVar = getAgent(config.agent).getApiKeyEnvVar();
+    } catch (err) {
+      fail(`${name}: unknown agent "${config.agent}"`, err instanceof Error ? err.message : String(err));
+      continue;
+    }
+    if (!byEnvVar.has(envVar)) byEnvVar.set(envVar, []);
+    byEnvVar.get(envVar).push(name);
+  }
+
+  if (byEnvVar.size === 0) return;
+
+  // VERCEL_OIDC_TOKEN authenticates the AI Gateway too, so the framework falls
+  // back to it for every agent.
+  const oidc = has('VERCEL_OIDC_TOKEN');
+
+  for (const [envVar, users] of [...byEnvVar].sort((a, b) => b[1].length - a[1].length)) {
+    const label = `${envVar} ${dim(`— ${users.length} experiment(s): ${list(users)}`)}`;
+    if (has(envVar)) {
+      pass(label);
+    } else if (oidc) {
+      pass(`${label}\n    ${dim('unset; falling back to VERCEL_OIDC_TOKEN')}`);
+    } else {
+      const hint = `Unset, and no VERCEL_OIDC_TOKEN to fall back on — the runner skips these experiments.`;
+      if (strict) fail(label, hint);
+      else caution(label, hint);
+    }
+  }
+}
+
+// Failure classifier
+
+/**
+ * Not required to run, but without it every infra hiccup is kept as a result
+ * and pollutes results/ — worth one line so it is a choice, not a surprise.
+ */
+function checkClassifier() {
+  console.log(heading('Failure classifier'));
+  if (has('AI_GATEWAY_API_KEY')) pass('enabled', 'via AI_GATEWAY_API_KEY');
+  else if (has('VERCEL_OIDC_TOKEN')) pass('enabled', 'via VERCEL_OIDC_TOKEN');
+  else
+    caution(
+      'disabled — infra/timeout failures will be kept as real results',
+      'Set AI_GATEWAY_API_KEY or VERCEL_OIDC_TOKEN to let housekeeping drop non-model failures.'
+    );
+}
+
+// main
+
+const patterns = process.argv.slice(2);
+const strict = patterns.length > 0;
+
+checkToolchain();
+checkFixtures();
+
+const experiments = await loadExperiments(patterns);
+if (experiments.length > 0) {
+  checkSandboxes(experiments);
+  checkAgentCredentials(experiments, strict);
+}
+checkClassifier();
+
+console.log('');
+if (errors.length > 0) {
+  console.log(bad(`${errors.length} blocking problem(s), ${warnings.length} warning(s).`));
+  process.exit(1);
+}
+if (warnings.length > 0) {
+  console.log(warn(`${warnings.length} warning(s) — you can run evals, but read the notes above.`));
+} else {
+  console.log(ok('Ready. Try: pnpm eval:smoke <experiment>'));
+}

--- a/scripts/sync-evals.ts
+++ b/scripts/sync-evals.ts
@@ -22,12 +22,22 @@ async function main(): Promise<void> {
   const evalsDir = join(process.cwd(), 'evals');
   const tmpDir = join(process.cwd(), '.sync-tmp');
 
+  // A ref is never a flag. Catching this here keeps a stray `pnpm sync-evals
+  // --foo` from reaching git as a ref (and, before the fetch-first order below,
+  // from deleting evals/ on the way to failing).
+  if (ref.startsWith('-')) {
+    throw new Error(`"${ref}" is not a ref. Usage: pnpm sync-evals [branch|tag|sha]`);
+  }
+
   console.log(`Syncing evals from vercel/next.js@${ref}...\n`);
 
-  // Clean slate
-  if (existsSync(evalsDir)) rmSync(evalsDir, { recursive: true });
   if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true });
 
+  // Fetch BEFORE touching evals/. A bad ref (typo, deleted branch, network
+  // blip) used to fail after the delete, leaving no fixtures at all — every
+  // later command then died in the framework's loader with an error that says
+  // nothing about the sync that caused it.
+  //
   // Sparse fetch. Use fetch + checkout (not clone --branch) so `ref` may be a
   // branch/tag OR a pinned commit SHA — clone --branch rejects raw SHAs.
   const repoDir = `${tmpDir}/next.js`;
@@ -41,7 +51,8 @@ async function main(): Promise<void> {
   );
   execSync(`git -C "${repoDir}" checkout -q FETCH_HEAD`, { stdio: 'inherit' });
 
-  // Copy evals into place
+  // Swap the fetched tree into place: only now is the old one expendable.
+  if (existsSync(evalsDir)) rmSync(evalsDir, { recursive: true });
   execSync(`cp -r "${tmpDir}/next.js/evals/evals" "${evalsDir}"`);
   rmSync(tmpDir, { recursive: true, force: true });
 


### PR DESCRIPTION
Asked to "set up a sandbox to run evals from this repo." Doing that on a clean box surfaced enough friction that fixing it seemed more useful than writing down the workarounds.

## What was broken

**A fresh clone has no evals.** `evals/` is git-ignored and synced from `vercel/next.js`, so every command dies in the framework's fixture loader with `Evals directory not found`. The README never mentioned `sync-evals` — it described authoring evals under `evals/`, which a sync overwrites.

**Sandbox auth fails confusingly when partly configured.** `@vercel/sandbox` only treats `VERCEL_TOKEN`/`VERCEL_TEAM_ID`/`VERCEL_PROJECT_ID` as credentials when *all three* are set. One or two falls through to the OIDC path and dies with `Could not get credentials from OIDC context` — naming neither the variable you forgot nor the path you meant. This box had exactly one of the three.

**Missing agent keys are near-silent** — one `skipping <experiment>` line mid-run.

**The README documented scripts that don't exist** (`eval:dry`, `eval:smoke`), said `npm install` for a pnpm-only repo, and told you to `cp .env.local .env` from a file that isn't in the repo. Its eval table stopped at agent-039; upstream is at agent-043.

## What this adds

| | |
|---|---|
| `pnpm preflight [experiment...]` | Toolchain, fixtures, sandbox auth, agent keys. Read-only. |
| `pnpm bootstrap [ref]` | install → sync → preflight, in order. |
| `.env.example` | Every variable, which agent wants it, and both sandbox auth paths. |
| `eval:dry`, `eval:smoke`, `eval:run`, `status`, `playground`, `typecheck` | Scripts for the commands the README describes. |
| `@types/node` | The shipped `tsconfig.json` includes `experiments/`, which read `process.env`, so `tsc --noEmit` could not pass. Now it does. |

`preflight` asks the framework the same questions the runner asks — `loadConfig` per experiment, then the agent's own `getApiKeyEnvVar()` — rather than pattern-matching configs, so it can't drift from real behavior. Bare invocation *warns* on missing agent keys (nobody holds all five providers' keys); naming an experiment makes them *errors*, since asking about an experiment you can't run should fail.

Two naming notes: the check is `preflight` and not `doctor`, and the bootstrap is `bootstrap` and not `setup`, because `pnpm doctor` and `pnpm setup` are built-in pnpm commands that silently shadow same-named scripts. `pnpm doctor` ran pnpm's built-in and exited 0 with no output.

## One real bug fixed

`sync-evals` deleted `evals/` *before* fetching, so a bad ref left you with no fixtures at all and a later error that said nothing about the sync that caused it. I hit this by passing it a stray flag. It now fetches first and swaps the tree into place, and rejects a flag-shaped ref up front.

```
$ pnpm sync-evals no-such-branch-xyz
fatal: couldn't find remote ref no-such-branch-xyz
$ ls evals | wc -l
24          # was 0 before this change
```

## Verified

Real Vercel Sandbox runs of `agent-025-prefer-next-link`, both 1/1:

- `claude-opus-5` — Claude Code via AI Gateway, 573s
- `glm-5.2` — OpenCode via AI Gateway, 666s

Also `pnpm typecheck` (clean), `pnpm test:cost` (8/8), `pnpm status --json` (what CI's `check-stale.mjs` consumes), and preflight across all its branches: full triple, OIDC-only, partial triple, missing fixtures, unknown experiment, globs, and `.env.local` pickup.

**No eval results are included** — housekeeping dropped the smoke-run directories, and `results/` is untouched in this diff.

## Not done

- The eval table in the README still needs hand-updating after an upstream sync. I added the four missing rows and a note that `ls evals/` is authoritative, but it will rot again.
- 42 of 56 experiments honour `EVAL_FILTER`; 14 don't. Left alone deliberately — editing an experiment config changes its fingerprint and would invalidate cached results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)