### PR TITLE
Make the eval setup reproducible from a fresh clone

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,37 @@
+# Copy to .env.local (git-ignored) and fill in. The runner loads .env.local first,
+# then .env — both override the ambient shell environment.
+#
+#   cp .env.example .env.local
+
+# ── Model access ──────────────────────────────────────────────────────────────
+# Required. Every experiment in experiments/ runs its agent through the Vercel AI
+# Gateway (`agent: "vercel-ai-gateway/..."`), and the failure classifier that
+# distinguishes model failures from infra failures uses the same key.
+# Create one at https://vercel.com/dashboard/ai-gateway
+AI_GATEWAY_API_KEY=
+
+# ── Sandbox access ────────────────────────────────────────────────────────────
+# Required. Every experiment sets `sandbox: "vercel"`, so evals need credentials
+# for Vercel Sandbox. Pick ONE of the two options below.
+#
+# Option 1 — OIDC token (recommended). Link this checkout to a Vercel project
+# once, then pull a token; `vercel env pull` refreshes it into .env.local:
+#
+#   vercel link
+#   vercel env pull .env.local
+#
+# VERCEL_OIDC_TOKEN expires (~12h), so re-pull before a long run.
+VERCEL_OIDC_TOKEN=
+
+# Option 2 — API token. All three are needed together: with a token but no
+# team/project, @vercel/sandbox falls back to an interactive "sign in with
+# Vercel" device flow and can create a stray default project.
+# Create a token at https://vercel.com/account/tokens
+# VERCEL_TOKEN=
+# VERCEL_TEAM_ID=team_...
+# VERCEL_PROJECT_ID=prj_...
+
+# ── Optional ──────────────────────────────────────────────────────────────────
+# Limit a run to a subset of evals; every experiment reads this
+# (`evals: process.env.EVAL_FILTER ?? "*"`). Supports globs.
+# EVAL_FILTER=agent-035-connection-dynamic

--- a/.github/workflows/eval-cache-check.yml
+++ b/.github/workflows/eval-cache-check.yml
@@ -21,6 +21,11 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # Cheap guards on the scripts/ + experiments/ code the steps below rely on.
+      - run: pnpm typecheck
+
+      - run: pnpm test:cost
+
       # Pinned to a known-good next.js canary commit. To adopt new/changed evals,
       # bump this SHA in a PR that reruns them for the experiments you're
       # refreshing and lists the remaining (experiment, eval) pairs in

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 /evals/
 .sync-tmp/
 .env*
+!.env.example

--- a/README.md
+++ b/README.md
@@ -5,41 +5,108 @@ Agent evaluations for Next.js coding tasks, powered by [`@vercel/agent-eval`](ht
 ## Setup
 
 ```bash
-npm install
-cp .env.local .env   # requires VERCEL_OIDC_TOKEN and AI_GATEWAY_API_KEY
+pnpm install                # pnpm is pinned via packageManager
+cp .env.example .env.local  # then fill in the keys — see below
+pnpm sync-evals             # fetch the eval fixtures; the repo ships none
 ```
+
+`.env.local` needs two things:
+
+| Variable | Why |
+|----------|-----|
+| `AI_GATEWAY_API_KEY` | Every experiment routes its agent through the Vercel AI Gateway, and the failure classifier uses the same key |
+| `VERCEL_OIDC_TOKEN`, or `VERCEL_TOKEN` + `VERCEL_TEAM_ID` + `VERCEL_PROJECT_ID` | Every experiment sets `sandbox: "vercel"` |
+
+For the OIDC route, run `vercel link` once, then `vercel env pull .env.local` to
+write (and later refresh) the token. Supply nothing and `@vercel/sandbox` drops
+into an interactive "sign in with Vercel" device flow — and with no team/project
+pinned it can create a stray default project. The runner loads `.env.local`
+first and `.env` second, so `.env` wins; both override the ambient shell
+environment.
 
 ## Scripts
 
-### `npm run eval`
+### `pnpm sync-evals [ref]`
 
-Runs agent evaluations with memoization. Only runs (model, eval) pairs that haven't been completed yet.
+The eval fixtures live in [`vercel/next.js`](https://github.com/vercel/next.js)
+under `evals/evals/`, not here — `evals/` is git-ignored and populated by a
+sparse checkout. **Nothing runs until you sync.**
 
 ```bash
-npm run eval              # Run only missing pairs
-npm run eval:dry          # Preview what would run
-npm run eval -- --force   # Re-run everything
-npm run eval:smoke        # Run 1 eval per experiment (sanity check)
+pnpm sync-evals        # canary (default)
+pnpm sync-evals <sha>  # a pinned commit, branch, or tag
 ```
+
+Syncing also runs `agent-eval refingerprint`, which carries CONFIG-only changes
+forward in cached results. A real eval-content change is deliberately left stale
+so `pnpm eval status` reports it instead of the old result being re-stamped as
+fresh. To match CI exactly, sync the SHA pinned in
+`.github/workflows/eval-cache-check.yml`.
+
+### `pnpm eval`
+
+Runs agent evaluations with memoization: only (model, eval) pairs that haven't
+been completed yet are executed.
+
+```bash
+pnpm eval status                     # new/changed evals and the work per experiment (read-only)
+pnpm eval run <exp> [exp...]         # run the missing pairs for one or more experiments
+pnpm eval run <exp> --smoke          # one eval only — checks keys, model ID, sandbox
+pnpm eval run <exp> --force          # ignore fingerprints, re-run everything
+pnpm eval                            # status, then pick an experiment interactively
+pnpm eval <experiment> --dry         # preview one experiment's plan, execute nothing
+```
+
+`run` (and the interactive picker) is the memoized path: it fingerprints each
+fixture, skips pairs that are already fresh, writes to
+`results/<experiment>/<timestamp>/`, and classifies failures afterwards so
+infra/timeout failures don't get stored as model results.
+
+**Passing a config name directly — `pnpm eval <experiment>` — is not the same
+command.** It ignores fingerprints (every eval re-runs) and writes to
+`results/<experiment>/<model>/<timestamp>/`, a path `status`,
+`check-stale.mjs`, and `export-results` never read. Keep that form for `--dry`.
+
+Experiment names are the filenames in `experiments/` (e.g. `claude-opus-5`);
+`status` and `run` also accept glob patterns. `EVAL_FILTER` narrows a run to a
+subset of evals — every config reads it (`evals: process.env.EVAL_FILTER ?? "*"`),
+so `EVAL_FILTER=agent-035-connection-dynamic pnpm eval run claude-opus-5` runs
+just that one.
 
 The runner automatically detects:
 - **New model added** → runs all evals for that model
 - **New eval added** → runs that eval for all models
 - **Already completed** → skips
 
-### `npm run export-results`
+Start with `pnpm eval run <experiment> --smoke` on a fresh checkout: it exercises
+the whole path (gateway key, sandbox credentials, agent CLI install, `next build`,
+assertions) for the price of a single eval. Smoke results are tagged and are
+never reused as real results.
+
+### `pnpm export-results`
 
 Exports clean results to `agent-results.json`. Non-model failures (infra/timeout) are automatically deleted during eval runs, so only valid model results are exported.
 
 Each experiment also gets an `avgCostUsd`: the mean list cost per eval. Tokens are read from each run's `transcript-raw.jsonl` (handled per harness in `scripts/cost.ts`) and multiplied by the list prices in `MODEL_PRICING`. A model with no price entry, or whose runs carry no token usage, exports `null` and renders as N/A. Prices are a snapshot, so re-run the export to refresh them.
 
-### `npm run test:cost`
+### `pnpm test:cost` and `pnpm typecheck`
 
-Unit tests for the token extraction and pricing in `scripts/cost.ts`.
+Unit tests for the token extraction and pricing in `scripts/cost.ts`, and a
+`tsc --noEmit` pass over `experiments/` and `scripts/`. Both run in CI.
+
+## CI
+
+`.github/workflows/eval-cache-check.yml` installs, syncs the pinned
+`vercel/next.js` SHA, and runs `scripts/check-stale.mjs`. The
+"which staleness is acceptable" policy lives in that script, not in the
+framework: it reads `agent-eval status --json` and fails on any new or changed
+eval whose `(experiment, eval)` pair isn't listed in `ACCEPTED_STALE`. To adopt
+new or changed evals, bump the SHA in the workflow, rerun the experiments you're
+refreshing, and list the remaining pairs in `ACCEPTED_STALE`.
 
 ## Eval structure
 
-Each eval is a self-contained Next.js project in `evals/`:
+Each eval is a self-contained Next.js project:
 
 ```
 evals/agent-031-proxy-middleware/
@@ -62,25 +129,27 @@ evals/agent-031-proxy-middleware/
 
 ## Adding a new eval
 
-1. Create a directory under `evals/` (e.g., `evals/agent-040-my-eval/`)
-2. Add `PROMPT.md` with the task description
-3. Add `EVAL.ts` with vitest assertions
-4. Add `package.json` with `"type": "module"` and `"build": "next build"`
-5. Add the Next.js source files the agent starts with
-6. Run `npm run eval` — it will automatically run the new eval for all models
+Evals are authored upstream — `evals/` here is a read-only sync target, and
+anything you add to it is wiped by the next `pnpm sync-evals`.
+
+1. Add the eval directory to `evals/evals/` in [`vercel/next.js`](https://github.com/vercel/next.js) and land it on `canary`
+2. Bump the pinned SHA in `.github/workflows/eval-cache-check.yml` to a commit that contains it
+3. `pnpm sync-evals <sha>` locally, then `pnpm eval status` — the new eval shows up as work for every experiment
+4. `pnpm eval run <experiment>` for the experiments you're refreshing, and add the remaining `(experiment, eval)` pairs to `ACCEPTED_STALE` in `scripts/check-stale.mjs`
 
 ## Adding a new model
 
 1. Create a config in `experiments/` (e.g., `experiments/gpt-5.ts`)
 2. Add the display name to `MODEL_NAMES` in `scripts/export-results.ts`
 3. Add the list price to `MODEL_PRICING` in `scripts/cost.ts` (or the cost column shows N/A)
-4. Run `npm run eval` — it will automatically run all evals for the new model
+4. For an `--agents-md` variant, map it to its base in `AGENTS_MD_PAIRS` in `scripts/export-results.ts` so the two share pricing
+5. Run `pnpm eval run <experiment>` — every eval runs for the new model
 
 ## Publishing to nextjs.org/evals
 
 After running evals:
 
-1. Export results: `npm run export-results`
+1. Export results: `pnpm export-results`
 2. Copy to front repo:
    ```bash
    cp agent-results.json <path-to-front>/apps/next-site/app/\(next-site\)/evals/agent-results.json
@@ -88,6 +157,8 @@ After running evals:
 3. Commit and deploy the front repo
 
 ## Current evals
+
+As synced at the SHA pinned in CI:
 
 | Eval | Tests |
 |------|-------|
@@ -111,6 +182,10 @@ After running evals:
 | agent-037 | updateTag() for read-your-own-writes |
 | agent-038 | Refresh page via revalidatePath |
 | agent-039 | Indirect proxy (request logging) |
+| agent-040 | Instant navigation — title paints immediately |
+| agent-041 | Optimize the partial prerendering shell |
+| agent-042 | Enable partial prerendering |
+| agent-043 | View transitions — shared-element morph |
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -6,9 +6,11 @@
     "eval": "agent-eval",
     "sync-evals": "tsx scripts/sync-evals.ts",
     "export-results": "tsx scripts/export-results.ts",
-    "test:cost": "tsx --test scripts/cost.test.ts"
+    "test:cost": "tsx --test scripts/cost.test.ts",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "tsx": "^4.19.0",
     "typescript": "^5.6.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
         specifier: ^1.5.1
         version: 1.5.1
     devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.1
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
@@ -270,8 +273,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@types/node@25.5.0':
-    resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
 
   '@vercel/agent-eval@1.5.1':
     resolution: {integrity: sha512-rqOQtgJ8IjRkFkbB+onoc7hDr7PrZQMPz+yi/glN0gXYdqL1l5nkkAXGDQIYOzWR9c6Qx+b7lwohb+e93xxcHw==}
@@ -719,8 +722,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@7.18.2:
-    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   undici@7.24.4:
     resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
@@ -947,9 +950,9 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@types/node@25.5.0':
+  '@types/node@22.20.1':
     dependencies:
-      undici-types: 7.18.2
+      undici-types: 6.21.0
 
   '@vercel/agent-eval@1.5.1':
     dependencies:
@@ -1312,7 +1315,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 25.5.0
+      '@types/node': 22.20.1
       long: 5.3.2
 
   pump@3.0.4:
@@ -1458,7 +1461,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  undici-types@7.18.2: {}
+  undici-types@6.21.0: {}
 
   undici@7.24.4: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "moduleResolution": "NodeNext",
     "strict": true,
     "skipLibCheck": true,
-    "noEmit": true
+    "noEmit": true,
+    "allowImportingTsExtensions": true
   },
-  "include": ["experiments"]
+  "include": ["experiments", "scripts"]
 }


### PR DESCRIPTION
Setting this repo up to actually run evals hits four undocumented walls. This fixes the walls and the docs together — no eval results or fixtures change.

## What was broken

**No env template.** The README said `cp .env.local .env`, but the repo ships neither file, and it never said where `VERCEL_OIDC_TOKEN` comes from. With no sandbox credentials, `@vercel/sandbox` drops into an interactive "sign in with Vercel" device authorization flow — and with no `VERCEL_TEAM_ID`/`VERCEL_PROJECT_ID` pinned it can create a stray default project. Added `.env.example` covering both credential routes, plus `!.env.example` in `.gitignore` (the trailing `.env*` rule was swallowing it).

**`pnpm sync-evals` wasn't a documented setup step.** `evals/` is git-ignored and sparse-checked out of `vercel/next.js`, so a fresh clone has zero fixtures and nothing to run. The README described `evals/` as if the eval sources lived here — including an "Adding a new eval" flow that tells you to create directories that the next sync deletes.

**`tsc --noEmit` failed with 54 errors.** `tsconfig.json` includes `experiments/`, every config reads `process.env.EVAL_FILTER`, and `@types/node` was never a devDependency — so `process`, `fs`, and `path` were all unresolved. Added `@types/node` and a `typecheck` script; the tsconfig now also covers `scripts/` (which needs `allowImportingTsExtensions` for `cost.test.ts`'s `./cost.ts` import). CI runs `typecheck` and `test:cost`.

**The documented run command bypasses memoization.** `agent-eval <config>` — which is what `npm run eval` resolved to — ignores fingerprints and writes to `results/<experiment>/<model>/<timestamp>/`. Nothing reads that path: `status`, `check-stale.mjs`, and `export-results` all expect `results/<experiment>/<timestamp>/`. I confirmed a run written there is invisible to `agent-eval status`. The memoized entry point is `agent-eval run <experiment>` (or the bare interactive picker). Docs now lead with `run` and flag the direct form as `--dry`-only.

Also: dropped the `eval:dry`/`eval:smoke` scripts from the docs (they never existed — `--dry`/`--smoke` are flags), switched examples to pnpm to match `packageManager` and CI, documented the `check-stale.mjs` staleness gate, and added agent-040 through agent-043 to the eval table.

## Validation

Everything below ran against the `vercel/next.js` SHA pinned in `eval-cache-check.yml`:

| Check | Result |
|---|---|
| `pnpm install --frozen-lockfile` | clean |
| `pnpm sync-evals 34d92a5` | 24 fixtures |
| `pnpm typecheck` | passes (was 54 errors) |
| `pnpm test:cost` | 8/8 |
| `node scripts/check-stale.mjs` | `Eval cache OK` |
| `pnpm export-results` | reproduces the committed `agent-results.json` byte-for-byte apart from `exportedAt` |
| `pnpm eval run claude-opus-5 --smoke` | agent-035 passed 1/1 in a real Vercel Sandbox (649s) |

The smoke run exercised the whole path: gateway auth, sandbox creation, `claude` CLI install, `next@canary` setup, the agent edit, `next build`, and the vitest assertions. Housekeeping deleted the smoke result afterwards, so `results/` is untouched.

One flake worth recording: the first smoke attempt failed in 36s with Claude Code's "run the postinstall manually" error — `npm install -g @anthropic-ai/claude-code@next` exited 0 inside the sandbox but left the native binary missing. It did not reproduce across three subsequent attempts (two direct sandbox repros of the install plus the passing run), so this looks like a transient npm optional-dependency miss rather than something to pin around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)