### PR TITLE
Bump @vercel/agent-eval to ^2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "typescript": "^5.6.0"
   },
   "dependencies": {
-    "@vercel/agent-eval": "^1.5.1"
+    "@vercel/agent-eval": "^2.2.1"
   },
   "packageManager": "pnpm@10.29.2+sha512.bef43fa759d91fd2da4b319a5a0d13ef7a45bb985a3d7342058470f9d2051a3ba8674e629672654686ef9443ad13a82da2beb9eeb3e0221c87b8154fff9d74b8"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@vercel/agent-eval':
-        specifier: ^1.5.1
-        version: 1.5.1
+        specifier: ^2.2.1
+        version: 2.2.1
     devDependencies:
       '@types/node':
         specifier: ^22.10.0
@@ -282,8 +282,8 @@ packages:
   '@types/node@22.20.1':
     resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
 
-  '@vercel/agent-eval@1.5.1':
-    resolution: {integrity: sha512-rqOQtgJ8IjRkFkbB+onoc7hDr7PrZQMPz+yi/glN0gXYdqL1l5nkkAXGDQIYOzWR9c6Qx+b7lwohb+e93xxcHw==}
+  '@vercel/agent-eval@2.2.1':
+    resolution: {integrity: sha512-TVowf/Q60kw8anu4oAIhb1fc4y8k4jhwjCPwdfNoy9m9W1LHBHZYaIi81QZ+7w2S77hvBi4CAoOnohovjA2Mow==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -960,7 +960,7 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@vercel/agent-eval@1.5.1':
+  '@vercel/agent-eval@2.2.1':
     dependencies:
       '@ai-sdk/anthropic': 1.2.12(zod@3.25.76)
       '@vercel/sandbox': 1.8.1


### PR DESCRIPTION
Moves the harness onto the current agent-eval line so runs pick up the grading fixes.