### PR TITLE
Verify published evals and invalidate the website cache from main CI

### DIFF
--- a/.github/workflows/eval-cache-check.yml
+++ b/.github/workflows/eval-cache-check.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   status-check:
@@ -35,3 +36,36 @@ jobs:
 
       - name: published export is current
         run: pnpm export-results --check
+
+  revalidate-site:
+    needs: status-check
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: invalidate the published evals cache
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const url = 'https://nextjs.org/api/evals/revalidate';
+            for (let attempt = 1; attempt <= 3; attempt++) {
+              try {
+                const token = await core.getIDToken(url);
+                const response = await fetch(url, {
+                  method: 'POST',
+                  headers: { authorization: `Bearer ${token}` },
+                  redirect: 'error',
+                  signal: AbortSignal.timeout(15_000),
+                });
+                if (!response.ok) throw new Error(`Revalidation returned HTTP ${response.status}`);
+                if ((await response.json()).revalidated !== true) throw new Error('Revalidation was not acknowledged');
+                core.info('Evals cache invalidated; stale content may be served for up to one hour.');
+                return;
+              } catch (error) {
+                if (attempt === 3) throw error;
+                core.warning(`Revalidation attempt ${attempt} failed: ${error.message}`);
+                await new Promise(resolve => setTimeout(resolve, 5000));
+              }
+            }

--- a/.github/workflows/eval-cache-check.yml
+++ b/.github/workflows/eval-cache-check.yml
@@ -32,3 +32,6 @@ jobs:
       # new/changed evals except those whose experiment is in its ACCEPTED_STALE list.
       - name: no unexpected stale evals
         run: node scripts/check-stale.mjs
+
+      - name: published export is current
+        run: pnpm export-results --check

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ are automatically deleted during eval runs, so only valid model results are
 exported.
 
 `pnpm export-results --check` verifies that the committed JSON matches a full
-export, ignoring only `metadata.exportedAt`. Run this check before publishing;
-it does not change the file. Export errors exit nonzero and an empty export is rejected.
+export, ignoring only `metadata.exportedAt`. CI runs this check without changing
+the file. Export errors exit nonzero and an empty export is rejected.
 
 Each experiment also gets an `avgCostUsd`: the mean list cost per eval. Tokens are
 read from each run's `transcript-raw.jsonl` (handled per harness in

--- a/README.md
+++ b/README.md
@@ -241,11 +241,23 @@ the [published JSON](https://raw.githubusercontent.com/vercel/next-evals-oss/mai
 on the server. Result updates require no copy, PR, or deployment in `front`.
 Merging this file to `main` publishes it to the website.
 
-The website revalidates its cache after five minutes on the next request. GitHub
-also caches the raw file (currently five minutes), and browser navigation may
-reuse a cached page, so updates are eventual rather than immediate. There is no
-webhook to configure. Revert the JSON change to roll back published results;
-the same cache refresh applies.
+After the checks pass on `main`, CI calls
+`POST https://nextjs.org/api/evals/revalidate` using a short-lived GitHub Actions
+OIDC token. Only the `main` workflow can invalidate production; PR runs only
+validate results. No shared secret needs provisioning.
+
+The website caches the snapshot without timed server revalidation. Invalidation
+starts a stale-while-revalidate window: subsequent requests can trigger a
+background refresh and receive the old snapshot for up to one hour, after which
+a server request must wait for fresh data. Browser navigation can reuse a page
+for five minutes, and already-open tabs need a refresh. Each upstream refresh
+bypasses GitHub's raw-file cache using a unique query parameter.
+
+Deploy the frontend endpoint before merging this CI integration. Delivery is
+retried three times and fails the `revalidate-site` job if unsuccessful. Rerun
+that job or manually dispatch this workflow on `main` to retry; there is no
+periodic refresh to repair a missed notification. Revert the JSON change and
+pass `main` CI to roll back published results through the same process.
 
 Keep the existing JSON shape compatible with the website. Coordinate changes
 to required fields or scoring semantics with `front`; the format is currently

--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ Exports clean results to `agent-results.json`. Non-model failures (infra/timeout
 are automatically deleted during eval runs, so only valid model results are
 exported.
 
+`pnpm export-results --check` verifies that the committed JSON matches a full
+export, ignoring only `metadata.exportedAt`. Run this check before publishing;
+it does not change the file. Export errors exit nonzero and an empty export is rejected.
+
 Each experiment also gets an `avgCostUsd`: the mean list cost per eval. Tokens are
 read from each run's `transcript-raw.jsonl` (handled per harness in
 `scripts/cost.ts`) and multiplied by the list prices in `MODEL_PRICING`. A model
@@ -228,12 +232,24 @@ refreshing, and record the rest in `ACCEPTED_STALE`.
 
 After running evals:
 
-1. Export results: `pnpm export-results`
-2. Copy to front repo:
-   ```bash
-   cp agent-results.json <path-to-front>/apps/next-site/app/\(next-site\)/evals/agent-results.json
-   ```
-3. Commit and deploy the front repo
+1. Export the full dataset: `pnpm export-results`.
+2. Include `agent-results.json` with the results in your PR to this repo.
+3. Merge the reviewed PR to `main`.
+
+Once the server-fetch integration in `front` is deployed, nextjs.org/evals reads
+the [published JSON](https://raw.githubusercontent.com/vercel/next-evals-oss/main/agent-results.json)
+on the server. Result updates require no copy, PR, or deployment in `front`.
+Merging this file to `main` publishes it to the website.
+
+The website revalidates its cache after five minutes on the next request. GitHub
+also caches the raw file (currently five minutes), and browser navigation may
+reuse a cached page, so updates are eventual rather than immediate. There is no
+webhook to configure. Revert the JSON change to roll back published results;
+the same cache refresh applies.
+
+Keep the existing JSON shape compatible with the website. Coordinate changes
+to required fields or scoring semantics with `front`; the format is currently
+unversioned.
 
 ## Model retention policy
 

--- a/scripts/export-results.ts
+++ b/scripts/export-results.ts
@@ -5,15 +5,17 @@
  * exports clean results to agent-results.json.
  *
  * Usage:
- *   npx tsx scripts/export-results.ts [experiments...]
- *   npx tsx scripts/export-results.ts  # exports from all experiments
+ *   pnpm export-results [experiments...]
+ *   pnpm export-results  # exports from all experiments
  *
- * Output: agent-results.json (copy this to front repo)
+ * Output: agent-results.json (published from main to nextjs.org/evals)
+ * Use --check to verify the committed export without writing it.
  */
 
 import { execSync } from 'node:child_process';
 import { readdir, readFile, writeFile, stat } from 'node:fs/promises';
 import { join } from 'node:path';
+import { isDeepStrictEqual } from 'node:util';
 import {
   MODEL_PRICING,
   extractRunTokens,
@@ -300,7 +302,7 @@ async function main(): Promise<void> {
   // whose content changed keep their last measured result until the model
   // is rerun — the board shows the previous measurement, not a hole.
   const missingByExperiment = new Map<string, Set<string>>();
-  const statusRaw = execSync('npx agent-eval status --json', {
+  const statusRaw = execSync('pnpm exec agent-eval status --json', {
     encoding: 'utf-8',
     maxBuffer: 64 * 1024 * 1024,
   });
@@ -311,11 +313,18 @@ async function main(): Promise<void> {
     missingByExperiment.set(w.experiment, new Set(w.new));
   }
 
-  let experiments = process.argv.slice(2);
+  const args = process.argv.slice(2);
+  const check = args.includes('--check');
+  let experiments = args.filter((arg) => arg !== '--check');
+  if (check && experiments.length > 0) {
+    throw new Error('--check verifies the full export; do not specify experiments');
+  }
 
   if (experiments.length === 0) {
     // Auto-discover all experiments with results
-    const allDirs = (await readdir(resultsDir)).filter((d) => !d.startsWith('.'));
+    const allDirs = (await readdir(resultsDir))
+      .filter((d) => !d.startsWith('.'))
+      .sort();
     const withResults: string[] = [];
     async function hasSummaryJson(dir: string): Promise<boolean> {
       const entries = (await readdir(dir).catch(() => [] as string[])).filter((e) => !e.startsWith('.'));
@@ -598,14 +607,29 @@ async function main(): Promise<void> {
   }
 
   const outputPath = join(process.cwd(), 'agent-results.json');
-  await writeFile(outputPath, JSON.stringify(exportedData, null, 2));
+  if (exportedData.metadata.experiments.length === 0) {
+    throw new Error('No valid experiments to publish');
+  }
+  if (check) {
+    const committed: ExportedData = JSON.parse(await readFile(outputPath, 'utf-8'));
+    // Export time changes on every invocation, even when all measurements match.
+    exportedData.metadata.exportedAt = committed.metadata.exportedAt;
+    if (!isDeepStrictEqual(committed, exportedData)) {
+      throw new Error('agent-results.json is out of date. Run pnpm export-results and commit it.');
+    }
+  } else {
+    await writeFile(outputPath, JSON.stringify(exportedData, null, 2));
+  }
 
   console.log('\n' + '-'.repeat(60));
-  console.log(`Exported to: ${outputPath}`);
+  console.log(`${check ? 'Verified' : 'Exported to'}: ${outputPath}`);
   console.log(
     `Total: ${totalResults} | Pass: ${totalSuccess} | Fail: ${totalResults - totalSuccess - totalNotAvailable} | N/A: ${totalNotAvailable}`
   );
   console.log('-'.repeat(60));
 }
 
-main().catch(console.error);
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Publish result updates by merging `agent-results.json` here, without copying it into the website repository. CI verifies that the committed JSON matches the saved results and, after successful checks on `main`, calls `https://nextjs.org/api/evals/revalidate` to refresh the website's indefinitely cached snapshot.

The new `revalidate-site` job runs only for `main` pushes or manual dispatches and authenticates with GitHub Actions OIDC. It retries delivery three times and fails on an unacknowledged or unsuccessful response. The website permits stale server responses for up to one hour after invalidation while refreshing in the background, then requires fresh data. PR runs validate results without calling production.

`pnpm export-results --check` compares the committed file with a complete export, ignores only the export timestamp, and never writes it. Full exports use deterministic experiment order; errors exit nonzero and empty exports are rejected. The JSON format remains unversioned.

Deploy the website's new endpoint before merging this producer integration. No shared secret needs configuration. Retry a missed notification by rerunning the failed job or manually dispatching this workflow on `main`; there is no periodic refresh fallback.

Validation:

- Export verification and the existing stale-result check passed against 754 results: 641 passes, 64 failures, 49 N/A. The previous PR revision also passed the export check in GitHub Actions.
- A timestamp-only change passed verification; a changed metric failed with exit code 1. Verification left the file untouched in both cases.
- TypeScript check passed for the exporter.
- Executed the new workflow script with isolated HTTP/identity stubs: successful delivery, transient HTTP/network retries, rejection of missing acknowledgments, and failure after three attempts all passed.
- The frontend tests verified signed-token authorization and the actual Next.js one-hour invalidation boundary. A real authenticated production callback awaits deployment and a successful `main` run.
- No evals were run or result artifacts changed by this PR.
